### PR TITLE
Add comprehensive tests for Safnari packages

### DIFF
--- a/src/config/config_test.go
+++ b/src/config/config_test.go
@@ -1,0 +1,89 @@
+package config
+
+import (
+	"flag"
+	"os"
+	"runtime"
+	"testing"
+)
+
+func TestParseCommaSeparated(t *testing.T) {
+	res := parseCommaSeparated("a,b , c")
+	if len(res) != 3 || res[1] != "b" {
+		t.Fatalf("unexpected result: %v", res)
+	}
+	if res := parseCommaSeparated(""); len(res) != 0 {
+		t.Fatalf("expected empty slice")
+	}
+}
+
+func TestFlagParsers(t *testing.T) {
+	fs := flag.NewFlagSet("test", flag.ContinueOnError)
+	fs.Int("i", 5, "")
+	fs.Int64("i64", 10, "")
+	fs.Bool("b", true, "")
+	fs.Parse([]string{"-i=7", "-i64=20", "-b=false"})
+	if getIntFlagValue(fs.Lookup("i")) != 7 {
+		t.Fatal("int parse failed")
+	}
+	if getInt64FlagValue(fs.Lookup("i64")) != 20 {
+		t.Fatal("int64 parse failed")
+	}
+	if parseBoolFlagValue(fs.Lookup("b")) {
+		t.Fatal("bool parse failed")
+	}
+}
+
+func TestLoadFromFile(t *testing.T) {
+	tmp, err := os.CreateTemp("", "cfg*.json")
+	if err != nil {
+		t.Fatalf("temp: %v", err)
+	}
+	tmp.WriteString(`{"start_paths":["/tmp"],"scan_files":false}`)
+	tmp.Close()
+	defer os.Remove(tmp.Name())
+
+	cfg := &Config{}
+	if err := cfg.loadFromFile(tmp.Name()); err != nil {
+		t.Fatalf("load: %v", err)
+	}
+	if cfg.StartPaths[0] != "/tmp" || cfg.ScanFiles {
+		t.Fatalf("unexpected cfg: %+v", cfg)
+	}
+}
+
+func TestValidate(t *testing.T) {
+	cfg := &Config{ScanFiles: false, ScanProcesses: false}
+	if err := cfg.validate(); err == nil {
+		t.Fatal("expected error when both scanning disabled")
+	}
+	cfg = &Config{ScanFiles: true}
+	if err := cfg.validate(); err == nil {
+		t.Fatal("expected error for missing paths")
+	}
+	cfg = &Config{ScanFiles: true, AllDrives: true}
+	if err := cfg.validate(); err == nil && runtime.GOOS != "windows" {
+		// On non-windows, AllDrives should cause error
+		t.Fatal("expected error for all drives on non-windows")
+	}
+	cfg = &Config{ScanFiles: true, StartPaths: []string{"/"}, OutputFormat: "xml"}
+	if err := cfg.validate(); err == nil {
+		t.Fatal("expected invalid output format error")
+	}
+	cfg = &Config{ScanFiles: true, StartPaths: []string{"/"}, OutputFormat: "json", ConcurrencyLevel: 0}
+	if err := cfg.validate(); err == nil {
+		t.Fatal("expected invalid concurrency")
+	}
+	cfg = &Config{ScanFiles: true, StartPaths: []string{"/"}, OutputFormat: "json", ConcurrencyLevel: 1, NiceLevel: "bad"}
+	if err := cfg.validate(); err == nil {
+		t.Fatal("expected invalid nice level")
+	}
+	cfg = &Config{ScanFiles: true, StartPaths: []string{"/"}, OutputFormat: "json", ConcurrencyLevel: 1, NiceLevel: "high", LogLevel: "bad"}
+	if err := cfg.validate(); err == nil {
+		t.Fatal("expected invalid log level")
+	}
+	cfg = &Config{ScanFiles: true, StartPaths: []string{"/"}, OutputFormat: "json", ConcurrencyLevel: 1, NiceLevel: "high", LogLevel: "info"}
+	if err := cfg.validate(); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}

--- a/src/hasher/hasher_test.go
+++ b/src/hasher/hasher_test.go
@@ -1,0 +1,33 @@
+package hasher
+
+import (
+	"os"
+	"testing"
+
+	"safnari/logger"
+)
+
+func TestComputeHashes(t *testing.T) {
+	logger.Init("info")
+	tmp, err := os.CreateTemp("", "hash-test")
+	if err != nil {
+		t.Fatalf("temp file: %v", err)
+	}
+	defer os.Remove(tmp.Name())
+	tmp.WriteString("hello world")
+	tmp.Close()
+
+	hashes := ComputeHashes(tmp.Name(), []string{"md5", "sha1", "sha256", "unknown"})
+	if hashes["md5"] != "5eb63bbbe01eeed093cb22bb8f5acdc3" {
+		t.Errorf("md5 mismatch: %s", hashes["md5"])
+	}
+	if hashes["sha1"] != "2aae6c35c94fcfb415dbe95f408b9ce91ee846ed" {
+		t.Errorf("sha1 mismatch: %s", hashes["sha1"])
+	}
+	if hashes["sha256"] != "b94d27b9934d3e08a52e52d7da7dabfac484efe37a5380ee9088f7ace2efcde9" {
+		t.Errorf("sha256 mismatch: %s", hashes["sha256"])
+	}
+	if _, ok := hashes["unknown"]; ok {
+		t.Errorf("unexpected hash for unknown algorithm")
+	}
+}

--- a/src/logger/logger_test.go
+++ b/src/logger/logger_test.go
@@ -1,0 +1,23 @@
+package logger
+
+import "testing"
+
+func TestLoggerFunctions(t *testing.T) {
+	Init("invalid") // should default to info
+	if log == nil {
+		t.Fatal("log not initialized")
+	}
+	// Avoid os.Exit on Fatal
+	log.ExitFunc = func(int) {}
+
+	Debug("debug")
+	Info("info")
+	Warn("warn")
+	Error("error")
+	Debugf("%s", "debugf")
+	Infof("%s", "infof")
+	Warnf("%s", "warnf")
+	Errorf("%s", "errorf")
+	Fatal("fatal")
+	Fatalf("%s", "fatalf")
+}

--- a/src/metadata/metadata_test.go
+++ b/src/metadata/metadata_test.go
@@ -1,0 +1,18 @@
+package metadata
+
+import "testing"
+
+func TestExtractMetadata(t *testing.T) {
+	cases := []string{
+		"image/jpeg",
+		"application/pdf",
+		"application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+		"unknown",
+	}
+	for _, mime := range cases {
+		meta := ExtractMetadata("", mime)
+		if meta == nil {
+			t.Fatalf("metadata map nil for %s", mime)
+		}
+	}
+}

--- a/src/output/output_test.go
+++ b/src/output/output_test.go
@@ -1,0 +1,42 @@
+package output
+
+import (
+	"os"
+	"testing"
+
+	"safnari/config"
+	"safnari/systeminfo"
+)
+
+func TestOutputLifecycle(t *testing.T) {
+	tmp, err := os.CreateTemp("", "out*.json")
+	if err != nil {
+		t.Fatalf("temp file: %v", err)
+	}
+	defer os.Remove(tmp.Name())
+
+	cfg := &config.Config{OutputFileName: tmp.Name()}
+	sysInfo := &systeminfo.SystemInfo{RunningProcesses: []systeminfo.ProcessInfo{}}
+	metrics := &Metrics{}
+	if err := Init(cfg, sysInfo, metrics); err != nil {
+		t.Fatalf("init: %v", err)
+	}
+	defer Close()
+
+	WriteData(map[string]interface{}{"path": "test"})
+	SetMetrics(Metrics{})
+}
+
+func TestJSONWriterFlush(t *testing.T) {
+	tmp, err := os.CreateTemp("", "flush*.json")
+	if err != nil {
+		t.Fatalf("temp file: %v", err)
+	}
+	defer os.Remove(tmp.Name())
+
+	w := NewJSONWriter(tmp)
+	w.data.Files = append(w.data.Files, map[string]interface{}{"a": 1})
+	if err := w.Flush(); err != nil {
+		t.Fatalf("flush: %v", err)
+	}
+}

--- a/src/scanner/scanner_test.go
+++ b/src/scanner/scanner_test.go
@@ -1,0 +1,160 @@
+package scanner
+
+import (
+	"context"
+	"os"
+	"runtime"
+	"testing"
+
+	"safnari/config"
+	"safnari/logger"
+	"safnari/output"
+	"safnari/systeminfo"
+)
+
+func init() {
+	logger.Init("error")
+}
+
+func TestIsHidden(t *testing.T) {
+	hidden, err := os.CreateTemp("", ".hidden")
+	if err != nil {
+		t.Fatalf("temp: %v", err)
+	}
+	defer os.Remove(hidden.Name())
+	fi, _ := os.Stat(hidden.Name())
+	if !isHidden(fi) {
+		t.Fatal("expected hidden")
+	}
+	tmp, _ := os.CreateTemp("", "visible")
+	defer os.Remove(tmp.Name())
+	fi2, _ := os.Stat(tmp.Name())
+	if isHidden(fi2) {
+		t.Fatal("expected visible")
+	}
+}
+
+func TestGetMimeType(t *testing.T) {
+	tmp, _ := os.CreateTemp("", "mime*.txt")
+	tmp.WriteString("hello")
+	tmp.Close()
+	defer os.Remove(tmp.Name())
+	_, err := getMimeType(tmp.Name())
+	if err != nil {
+		t.Fatalf("mime: %v", err)
+	}
+}
+
+func TestShouldSearchContent(t *testing.T) {
+	if !shouldSearchContent("text/plain") {
+		t.Fatal("text should search")
+	}
+	if shouldSearchContent("image/png") {
+		t.Fatal("image should not search")
+	}
+}
+
+func TestScanForSensitiveData(t *testing.T) {
+	tmp, _ := os.CreateTemp("", "data*.txt")
+	content := "contact me at test@example.com"
+	tmp.WriteString(content)
+	tmp.Close()
+	defer os.Remove(tmp.Name())
+	patterns := GetPatterns([]string{"email"})
+	matches := scanForSensitiveData(tmp.Name(), patterns)
+	if len(matches["email"]) == 0 {
+		t.Fatal("expected email match")
+	}
+}
+
+func TestGetFileAttributes(t *testing.T) {
+	tmp, _ := os.CreateTemp("", "attr")
+	tmp.Close()
+	defer os.Remove(tmp.Name())
+	os.Chmod(tmp.Name(), 0444)
+	fi, _ := os.Stat(tmp.Name())
+	attrs := getFileAttributes(fi)
+	if len(attrs) == 0 {
+		t.Fatal("expected some attributes")
+	}
+}
+
+func TestCollectFileData(t *testing.T) {
+	tmp, _ := os.CreateTemp("", "collect*.txt")
+	tmp.WriteString("hello test@example.com")
+	tmp.Close()
+	defer os.Remove(tmp.Name())
+	fi, _ := os.Stat(tmp.Name())
+	cfg := &config.Config{HashAlgorithms: []string{"md5"}, MaxFileSize: 1024}
+	patterns := GetPatterns([]string{"email"})
+	data, err := collectFileData(tmp.Name(), fi, cfg, patterns)
+	if err != nil {
+		t.Fatalf("collect: %v", err)
+	}
+	if data["path"] != tmp.Name() {
+		t.Fatalf("unexpected path")
+	}
+	if _, ok := data["hashes"].(map[string]string)["md5"]; !ok {
+		t.Fatalf("hash missing")
+	}
+}
+
+func TestProcessFile(t *testing.T) {
+	tmp, _ := os.CreateTemp("", "proc*.txt")
+	tmp.WriteString("hello test@example.com")
+	tmp.Close()
+	defer os.Remove(tmp.Name())
+
+	outFile, _ := os.CreateTemp("", "out*.json")
+	defer os.Remove(outFile.Name())
+	cfg := &config.Config{HashAlgorithms: []string{"md5"}, MaxFileSize: 1024, OutputFileName: outFile.Name()}
+	sys := &systeminfo.SystemInfo{RunningProcesses: []systeminfo.ProcessInfo{}}
+	metrics := &output.Metrics{}
+	if err := output.Init(cfg, sys, metrics); err != nil {
+		t.Fatalf("output init: %v", err)
+	}
+	defer output.Close()
+
+	patterns := GetPatterns([]string{"email"})
+	ctx := context.Background()
+	ProcessFile(ctx, tmp.Name(), cfg, patterns)
+}
+
+func TestCountTotalFiles(t *testing.T) {
+	dir := t.TempDir()
+	os.WriteFile(dir+"/a.txt", []byte("a"), 0644)
+	os.WriteFile(dir+"/b.txt", []byte("b"), 0644)
+	cfg := &config.Config{}
+	count, err := countTotalFiles(dir, cfg)
+	if err != nil || count != 2 {
+		t.Fatalf("count: %v %d", err, count)
+	}
+}
+
+func TestAdjustConcurrency(t *testing.T) {
+	cfg := &config.Config{NiceLevel: "high"}
+	adjustConcurrency(cfg)
+	if cfg.ConcurrencyLevel != runtime.NumCPU() {
+		t.Fatalf("high expected %d got %d", runtime.NumCPU(), cfg.ConcurrencyLevel)
+	}
+	cfg = &config.Config{NiceLevel: "medium"}
+	adjustConcurrency(cfg)
+	if cfg.ConcurrencyLevel != runtime.NumCPU()/2 && cfg.ConcurrencyLevel != 1 {
+		t.Fatalf("medium got %d", cfg.ConcurrencyLevel)
+	}
+	cfg = &config.Config{NiceLevel: "low"}
+	adjustConcurrency(cfg)
+	if cfg.ConcurrencyLevel != 1 {
+		t.Fatalf("low expected 1")
+	}
+}
+
+func TestGetFileOwnership(t *testing.T) {
+	tmp, _ := os.CreateTemp("", "owner")
+	tmp.Close()
+	defer os.Remove(tmp.Name())
+	owner, err := getFileOwnership(tmp.Name())
+	if err != nil || owner == "" {
+		t.Fatalf("ownership: %v %s", err, owner)
+	}
+}

--- a/src/systeminfo/systeminfo_test.go
+++ b/src/systeminfo/systeminfo_test.go
@@ -1,0 +1,34 @@
+package systeminfo
+
+import (
+	"testing"
+
+	"safnari/config"
+	"safnari/logger"
+)
+
+func init() {
+	logger.Init("error")
+}
+
+func TestGetSystemInfo(t *testing.T) {
+	cfg := &config.Config{}
+	info, err := GetSystemInfo(cfg)
+	if err != nil {
+		t.Fatalf("get: %v", err)
+	}
+	if info == nil {
+		t.Fatal("nil info")
+	}
+}
+
+func TestGatherRunningProcesses(t *testing.T) {
+	sys := &SystemInfo{}
+	if err := gatherRunningProcesses(sys, false); err != nil {
+		t.Fatalf("gather: %v", err)
+	}
+	sys2 := &SystemInfo{}
+	if err := gatherRunningProcesses(sys2, true); err != nil {
+		t.Fatalf("gather extended: %v", err)
+	}
+}

--- a/src/utils/drive_utils_unix_test.go
+++ b/src/utils/drive_utils_unix_test.go
@@ -1,0 +1,13 @@
+package utils
+
+import "testing"
+
+func TestGetLocalDrives(t *testing.T) {
+	drives, err := GetLocalDrives()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(drives) == 0 {
+		t.Fatal("expected at least one drive")
+	}
+}

--- a/src/utils/patterns_test.go
+++ b/src/utils/patterns_test.go
@@ -1,0 +1,36 @@
+package utils
+
+import "testing"
+
+func TestShouldInclude(t *testing.T) {
+	if !ShouldInclude("file.txt", nil, nil) {
+		t.Fatal("expected include by default")
+	}
+	if ShouldInclude("file.txt", []string{"*.jpg"}, nil) {
+		t.Fatal("should not include unmatched include pattern")
+	}
+	if !ShouldInclude("photo.jpg", []string{"*.jpg"}, nil) {
+		t.Fatal("should include matching include pattern")
+	}
+	if ShouldInclude("secret.txt", nil, []string{"secret.*"}) {
+		t.Fatal("should exclude matching exclude pattern")
+	}
+	if !ShouldInclude("notes.txt", nil, []string{"secret.*"}) {
+		t.Fatal("should include when exclude does not match")
+	}
+	if !ShouldInclude("path/to/file.go", []string{".*file\\.go$"}, nil) {
+		t.Fatal("should match regex include pattern")
+	}
+}
+
+func TestMatchesAnyPattern(t *testing.T) {
+	if !matchesAnyPattern("file.txt", []string{"*.txt"}) {
+		t.Fatal("expected wildcard match")
+	}
+	if matchesAnyPattern("file.txt", []string{"*.jpg"}) {
+		t.Fatal("unexpected match")
+	}
+	if !matchesAnyPattern("dir/file.go", []string{"dir/.*\\.go"}) {
+		t.Fatal("expected regex match")
+	}
+}


### PR DESCRIPTION
## Summary
- add unit tests for configuration parsing and validation
- verify hash algorithms and logger functionality
- test output writer, scanner utilities, system info gathering, and utility helpers

## Testing
- `go test ./...`
- `go vet ./...`


------
https://chatgpt.com/codex/tasks/task_e_68b912c360e08333b9420220d42a23d6