### PR TITLE
Stream file results directly to output

### DIFF
--- a/src/output/output_test.go
+++ b/src/output/output_test.go
@@ -2,6 +2,9 @@ package output
 
 import (
 	"os"
+	"strconv"
+	"strings"
+	"sync"
 	"testing"
 
 	"safnari/config"
@@ -18,25 +21,75 @@ func TestOutputLifecycle(t *testing.T) {
 	cfg := &config.Config{OutputFileName: tmp.Name()}
 	sysInfo := &systeminfo.SystemInfo{RunningProcesses: []systeminfo.ProcessInfo{}}
 	metrics := &Metrics{}
-	if err := Init(cfg, sysInfo, metrics); err != nil {
+	w, err := New(cfg, sysInfo, metrics)
+	if err != nil {
 		t.Fatalf("init: %v", err)
 	}
-	defer Close()
 
-	WriteData(map[string]interface{}{"path": "test"})
-	SetMetrics(Metrics{})
+	w.WriteData(map[string]interface{}{"path": "test"})
+	w.SetMetrics(Metrics{})
+	w.Close()
 }
 
-func TestJSONWriterFlush(t *testing.T) {
-	tmp, err := os.CreateTemp("", "flush*.json")
+func TestWriteDataStreaming(t *testing.T) {
+	tmp, err := os.CreateTemp("", "stream*.json")
 	if err != nil {
 		t.Fatalf("temp file: %v", err)
 	}
 	defer os.Remove(tmp.Name())
 
-	w := NewJSONWriter(tmp)
-	w.data.Files = append(w.data.Files, map[string]interface{}{"a": 1})
-	if err := w.Flush(); err != nil {
-		t.Fatalf("flush: %v", err)
+	cfg := &config.Config{OutputFileName: tmp.Name()}
+	sysInfo := &systeminfo.SystemInfo{RunningProcesses: []systeminfo.ProcessInfo{}}
+	w, err := New(cfg, sysInfo, &Metrics{})
+	if err != nil {
+		t.Fatalf("init: %v", err)
+	}
+
+	w.WriteData(map[string]interface{}{"path": "early"})
+
+	content, err := os.ReadFile(tmp.Name())
+	if err != nil {
+		t.Fatalf("read file: %v", err)
+	}
+	if !strings.Contains(string(content), "\"path\": \"early\"") {
+		t.Fatalf("expected written data, got: %s", string(content))
+	}
+
+	w.Close()
+}
+
+func TestWriteDataConcurrent(t *testing.T) {
+	tmp, err := os.CreateTemp("", "concurrent*.json")
+	if err != nil {
+		t.Fatalf("temp file: %v", err)
+	}
+	defer os.Remove(tmp.Name())
+
+	cfg := &config.Config{OutputFileName: tmp.Name()}
+	sysInfo := &systeminfo.SystemInfo{RunningProcesses: []systeminfo.ProcessInfo{}}
+	w, err := New(cfg, sysInfo, &Metrics{})
+	if err != nil {
+		t.Fatalf("init: %v", err)
+	}
+
+	var wg sync.WaitGroup
+	for i := 0; i < 5; i++ {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			w.WriteData(map[string]interface{}{"path": i})
+		}(i)
+	}
+	wg.Wait()
+	w.Close()
+
+	content, err := os.ReadFile(tmp.Name())
+	if err != nil {
+		t.Fatalf("read: %v", err)
+	}
+	for i := 0; i < 5; i++ {
+		if !strings.Contains(string(content), "\"path\": "+strconv.Itoa(i)) {
+			t.Fatalf("missing entry %d", i)
+		}
 	}
 }

--- a/src/scanner/file_processor.go
+++ b/src/scanner/file_processor.go
@@ -1,208 +1,208 @@
 package scanner
 
 import (
-    "context"
-    "io"
-    "os"
-    "regexp"
-    "strings"
-    "time"
+	"context"
+	"io"
+	"os"
+	"regexp"
+	"strings"
+	"time"
 
-    "safnari/config"
-    "safnari/hasher"
-    "safnari/logger"
-    "safnari/metadata"
-    "safnari/output"
+	"safnari/config"
+	"safnari/hasher"
+	"safnari/logger"
+	"safnari/metadata"
+	"safnari/output"
 
-    "github.com/djherbis/times"
-    "github.com/h2non/filetype"
+	"github.com/djherbis/times"
+	"github.com/h2non/filetype"
 )
 
-func ProcessFile(ctx context.Context, path string, cfg *config.Config, sensitivePatterns map[string]*regexp.Regexp) {
-    select {
-    case <-ctx.Done():
-        return
-    default:
-    }
+func ProcessFile(ctx context.Context, path string, cfg *config.Config, w *output.Writer, sensitivePatterns map[string]*regexp.Regexp) {
+	select {
+	case <-ctx.Done():
+		return
+	default:
+	}
 
-    fileInfo, err := os.Stat(path)
-    if err != nil {
-        logger.Warnf("Failed to stat file %s: %v", path, err)
-        return
-    }
+	fileInfo, err := os.Stat(path)
+	if err != nil {
+		logger.Warnf("Failed to stat file %s: %v", path, err)
+		return
+	}
 
-    if fileInfo.IsDir() {
-        return
-    }
+	if fileInfo.IsDir() {
+		return
+	}
 
-    if fileInfo.Size() > cfg.MaxFileSize {
-        logger.Debugf("Skipping large file %s", path)
-        return
-    }
+	if fileInfo.Size() > cfg.MaxFileSize {
+		logger.Debugf("Skipping large file %s", path)
+		return
+	}
 
-    fileData, err := collectFileData(path, fileInfo, cfg, sensitivePatterns)
-    if err != nil {
-        logger.Warnf("Failed to process file %s: %v", path, err)
-        return
-    }
-    output.WriteData(fileData)
+	fileData, err := collectFileData(path, fileInfo, cfg, sensitivePatterns)
+	if err != nil {
+		logger.Warnf("Failed to process file %s: %v", path, err)
+		return
+	}
+	w.WriteData(fileData)
 }
 
 func collectFileData(path string, fileInfo os.FileInfo, cfg *config.Config, sensitivePatterns map[string]*regexp.Regexp) (map[string]interface{}, error) {
-    data := make(map[string]interface{})
-    data["path"] = path
-    data["name"] = fileInfo.Name()
-    data["size"] = fileInfo.Size()
-    data["mod_time"] = fileInfo.ModTime().Format(time.RFC3339)
+	data := make(map[string]interface{})
+	data["path"] = path
+	data["name"] = fileInfo.Name()
+	data["size"] = fileInfo.Size()
+	data["mod_time"] = fileInfo.ModTime().Format(time.RFC3339)
 
-    // Get access and creation times using times package
-    t, err := times.Stat(path)
-    if err == nil {
-        if t.HasBirthTime() {
-            data["creation_time"] = t.BirthTime().Format(time.RFC3339)
-        } else {
-            data["creation_time"] = ""
-        }
-        data["access_time"] = t.AccessTime().Format(time.RFC3339)
-        data["change_time"] = t.ChangeTime().Format(time.RFC3339)
-    } else {
-        data["creation_time"] = ""
-        data["access_time"] = ""
-        data["change_time"] = ""
-    }
+	// Get access and creation times using times package
+	t, err := times.Stat(path)
+	if err == nil {
+		if t.HasBirthTime() {
+			data["creation_time"] = t.BirthTime().Format(time.RFC3339)
+		} else {
+			data["creation_time"] = ""
+		}
+		data["access_time"] = t.AccessTime().Format(time.RFC3339)
+		data["change_time"] = t.ChangeTime().Format(time.RFC3339)
+	} else {
+		data["creation_time"] = ""
+		data["access_time"] = ""
+		data["change_time"] = ""
+	}
 
-    // Get file attributes
-    data["attributes"] = getFileAttributes(fileInfo)
+	// Get file attributes
+	data["attributes"] = getFileAttributes(fileInfo)
 
-    // Get file permissions
-    data["permissions"] = fileInfo.Mode().Perm().String()
+	// Get file permissions
+	data["permissions"] = fileInfo.Mode().Perm().String()
 
-    // Get file owner
-    owner, err := getFileOwnership(path)
-    if err == nil {
-        data["owner"] = owner
-    } else {
-        data["owner"] = ""
-    }
+	// Get file owner
+	owner, err := getFileOwnership(path)
+	if err == nil {
+		data["owner"] = owner
+	} else {
+		data["owner"] = ""
+	}
 
-    // Determine MIME type
-    mimeType, err := getMimeType(path)
-    if err != nil {
-        mimeType = "unknown"
-    }
-    data["mime_type"] = mimeType
+	// Determine MIME type
+	mimeType, err := getMimeType(path)
+	if err != nil {
+		mimeType = "unknown"
+	}
+	data["mime_type"] = mimeType
 
-    // Compute hashes
-    hashes := hasher.ComputeHashes(path, cfg.HashAlgorithms)
-    data["hashes"] = hashes
+	// Compute hashes
+	hashes := hasher.ComputeHashes(path, cfg.HashAlgorithms)
+	data["hashes"] = hashes
 
-    // Extract metadata if applicable
-    meta := metadata.ExtractMetadata(path, mimeType)
-    data["metadata"] = meta
+	// Extract metadata if applicable
+	meta := metadata.ExtractMetadata(path, mimeType)
+	data["metadata"] = meta
 
-    // Sensitive Data Scanning
-    if shouldSearchContent(mimeType) && len(sensitivePatterns) > 0 {
-        matches := scanForSensitiveData(path, sensitivePatterns)
-        if len(matches) > 0 {
-            data["sensitive_data"] = matches
-        }
-    }
+	// Sensitive Data Scanning
+	if shouldSearchContent(mimeType) && len(sensitivePatterns) > 0 {
+		matches := scanForSensitiveData(path, sensitivePatterns)
+		if len(matches) > 0 {
+			data["sensitive_data"] = matches
+		}
+	}
 
-    return data, nil
+	return data, nil
 }
 
 func getFileAttributes(fileInfo os.FileInfo) []string {
-    var attrs []string
-    mode := fileInfo.Mode()
+	var attrs []string
+	mode := fileInfo.Mode()
 
-    if mode&os.ModeSymlink != 0 {
-        attrs = append(attrs, "symlink")
-    }
-    if isHidden(fileInfo) {
-        attrs = append(attrs, "hidden")
-    }
-    if mode&0222 == 0 {
-        attrs = append(attrs, "read-only")
-    }
-    return attrs
+	if mode&os.ModeSymlink != 0 {
+		attrs = append(attrs, "symlink")
+	}
+	if isHidden(fileInfo) {
+		attrs = append(attrs, "hidden")
+	}
+	if mode&0222 == 0 {
+		attrs = append(attrs, "read-only")
+	}
+	return attrs
 }
 
 func isHidden(fileInfo os.FileInfo) bool {
-    name := fileInfo.Name()
-    if name == "." || name == ".." {
-        return false
-    }
-    if name[0] == '.' {
-        return true
-    }
-    return false
+	name := fileInfo.Name()
+	if name == "." || name == ".." {
+		return false
+	}
+	if name[0] == '.' {
+		return true
+	}
+	return false
 }
 
 func getMimeType(path string) (string, error) {
-    file, err := os.Open(path)
-    if err != nil {
-        return "", err
-    }
-    defer file.Close()
+	file, err := os.Open(path)
+	if err != nil {
+		return "", err
+	}
+	defer file.Close()
 
-    buf := make([]byte, 261)
-    _, err = file.Read(buf)
-    if err != nil && err != io.EOF {
-        return "", err
-    }
+	buf := make([]byte, 261)
+	_, err = file.Read(buf)
+	if err != nil && err != io.EOF {
+		return "", err
+	}
 
-    kind, err := filetype.Match(buf)
-    if err != nil {
-        return "", err
-    }
-    return kind.MIME.Value, nil
+	kind, err := filetype.Match(buf)
+	if err != nil {
+		return "", err
+	}
+	return kind.MIME.Value, nil
 }
 
 func shouldSearchContent(mimeType string) bool {
-    return strings.HasPrefix(mimeType, "text/") ||
-        strings.Contains(mimeType, "json") ||
-        strings.Contains(mimeType, "xml") ||
-        strings.Contains(mimeType, "html") ||
-        strings.Contains(mimeType, "javascript")
+	return strings.HasPrefix(mimeType, "text/") ||
+		strings.Contains(mimeType, "json") ||
+		strings.Contains(mimeType, "xml") ||
+		strings.Contains(mimeType, "html") ||
+		strings.Contains(mimeType, "javascript")
 }
 
 func scanForSensitiveData(path string, patterns map[string]*regexp.Regexp) map[string][]string {
-    matches := make(map[string][]string)
+	matches := make(map[string][]string)
 
-    file, err := os.Open(path)
-    if err != nil {
-        logger.Warnf("Failed to open file for scanning %s: %v", path, err)
-        return matches
-    }
-    defer file.Close()
+	file, err := os.Open(path)
+	if err != nil {
+		logger.Warnf("Failed to open file for scanning %s: %v", path, err)
+		return matches
+	}
+	defer file.Close()
 
-    stat, err := file.Stat()
-    if err != nil {
-        return matches
-    }
+	stat, err := file.Stat()
+	if err != nil {
+		return matches
+	}
 
-    // Limit scanning to files below a certain size (e.g., 10 MB)
-    const maxSize = 10 * 1024 * 1024
-    if stat.Size() > maxSize {
-        logger.Debugf("Skipping content scanning for large file %s", path)
-        return matches
-    }
+	// Limit scanning to files below a certain size (e.g., 10 MB)
+	const maxSize = 10 * 1024 * 1024
+	if stat.Size() > maxSize {
+		logger.Debugf("Skipping content scanning for large file %s", path)
+		return matches
+	}
 
-    content, err := io.ReadAll(file)
-    if err != nil {
-        logger.Warnf("Failed to read file %s: %v", path, err)
-        return matches
-    }
+	content, err := io.ReadAll(file)
+	if err != nil {
+		logger.Warnf("Failed to read file %s: %v", path, err)
+		return matches
+	}
 
-    textContent := string(content)
-    for dataType, pattern := range patterns {
-        found := pattern.FindAllString(textContent, -1)
-        if len(found) > 0 {
-            matches[dataType] = found
-        }
-    }
+	textContent := string(content)
+	for dataType, pattern := range patterns {
+		found := pattern.FindAllString(textContent, -1)
+		if len(found) > 0 {
+			matches[dataType] = found
+		}
+	}
 
-    return matches
+	return matches
 }
 
 // getFileOwnership function is implemented in platform-specific files:

--- a/src/scanner/scanner.go
+++ b/src/scanner/scanner.go
@@ -17,7 +17,7 @@ import (
 	"golang.org/x/time/rate"
 )
 
-func ScanFiles(ctx context.Context, cfg *config.Config, metrics *output.Metrics) error {
+func ScanFiles(ctx context.Context, cfg *config.Config, metrics *output.Metrics, w *output.Writer) error {
 	// If cfg.AllDrives is true, get all local drives
 	if cfg.AllDrives {
 		drives, err := utils.GetLocalDrives()
@@ -104,9 +104,8 @@ func ScanFiles(ctx context.Context, cfg *config.Config, metrics *output.Metrics)
 				default:
 					// Continue processing
 				}
-				ProcessFile(ctx, filePath, cfg, sensitivePatterns)
+				ProcessFile(ctx, filePath, cfg, w, sensitivePatterns)
 				bar.Add(1)
-				metrics.FilesProcessed++
 			}
 		}()
 	}

--- a/src/scanner/scanner_test.go
+++ b/src/scanner/scanner_test.go
@@ -110,14 +110,15 @@ func TestProcessFile(t *testing.T) {
 	cfg := &config.Config{HashAlgorithms: []string{"md5"}, MaxFileSize: 1024, OutputFileName: outFile.Name()}
 	sys := &systeminfo.SystemInfo{RunningProcesses: []systeminfo.ProcessInfo{}}
 	metrics := &output.Metrics{}
-	if err := output.Init(cfg, sys, metrics); err != nil {
+	w, err := output.New(cfg, sys, metrics)
+	if err != nil {
 		t.Fatalf("output init: %v", err)
 	}
-	defer output.Close()
+	defer w.Close()
 
 	patterns := GetPatterns([]string{"email"})
 	ctx := context.Background()
-	ProcessFile(ctx, tmp.Name(), cfg, patterns)
+	ProcessFile(ctx, tmp.Name(), cfg, w, patterns)
 }
 
 func TestCountTotalFiles(t *testing.T) {


### PR DESCRIPTION
## Summary
- stream scan results directly to JSON with a dedicated writer per scan
- make the output writer concurrency-safe and pass it through scanning pipeline
- add tests for streaming and concurrent writes

## Testing
- `make lint`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_68b9156ddde483338f8d6bbd2f025296