### PR TITLE
refactor: simplify CLI flags with sensible defaults

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,13 +30,20 @@ Check the [releases page](https://github.com/Forgence/Safnari/releases) for bina
 
 ## Usage
 
-Run the binary with `--help` to see all available options. Example:
+Run the binary with `-h` to see all available options. By default Safnari scans
+the current working directory using a concurrency level equal to the number of
+logical CPUs. It does not search for any strings or sensitive data types unless
+explicitly requested and writes results to a timestamped file named
+`safnari-<human-readable>-<unix>.json`.
 
 ```sh
 ./bin/safnari-$(go env GOOS)-$(go env GOARCH) --path /home/user --hashes sha256 --search "password"
 ```
 
-This will scan `/home/user`, compute SHA-256 hashes, search for the term "password," and write results to `output.json` by default.
+This will scan `/home/user`, compute SHA-256 hashes, search for the term
+`password`, and write results to a file such as
+`safnari-20240130-150405-1706625005.json` unless an alternate output filename
+is provided.
 
 ## Contributing
 

--- a/src/config/config.go
+++ b/src/config/config.go
@@ -1,221 +1,195 @@
 package config
 
 import (
-    "encoding/json"
-    "flag"
-    "fmt"
-    "io/ioutil"
-    "os"
-    "runtime"
-    "strconv"
-    "strings"
+	"encoding/json"
+	"flag"
+	"fmt"
+	"io/ioutil"
+	"runtime"
+	"strings"
+	"time"
 )
 
 type Config struct {
-    StartPaths          []string `json:"start_paths"`
-    AllDrives           bool     `json:"all_drives"`
-    ScanFiles           bool     `json:"scan_files"`
-    ScanProcesses       bool     `json:"scan_processes"`
-    OutputFormat        string   `json:"output_format"`
-    OutputFileName      string   `json:"output_file_name"`
-    ConcurrencyLevel    int      `json:"concurrency_level"`
-    NiceLevel           string   `json:"nice_level"`
-    HashAlgorithms      []string `json:"hash_algorithms"`
-    SearchTerms         []string `json:"search_terms"`
-    IncludePatterns     []string `json:"include_patterns"`
-    ExcludePatterns     []string `json:"exclude_patterns"`
-    MaxFileSize         int64    `json:"max_file_size"`
-    MaxOutputFileSize   int64    `json:"max_output_file_size"`
-    LogLevel            string   `json:"log_level"`
-    MaxIOPerSecond      int      `json:"max_io_per_second"`
-    ConfigFile          string   `json:"config_file"`
-    ExtendedProcessInfo bool     `json:"extended_process_info"`
-    SensitiveDataTypes  []string `json:"sensitive_data_types"`
+	StartPaths          []string `json:"start_paths"`
+	AllDrives           bool     `json:"all_drives"`
+	ScanFiles           bool     `json:"scan_files"`
+	ScanProcesses       bool     `json:"scan_processes"`
+	OutputFormat        string   `json:"output_format"`
+	OutputFileName      string   `json:"output_file_name"`
+	ConcurrencyLevel    int      `json:"concurrency_level"`
+	NiceLevel           string   `json:"nice_level"`
+	HashAlgorithms      []string `json:"hash_algorithms"`
+	SearchTerms         []string `json:"search_terms"`
+	IncludePatterns     []string `json:"include_patterns"`
+	ExcludePatterns     []string `json:"exclude_patterns"`
+	MaxFileSize         int64    `json:"max_file_size"`
+	MaxOutputFileSize   int64    `json:"max_output_file_size"`
+	LogLevel            string   `json:"log_level"`
+	MaxIOPerSecond      int      `json:"max_io_per_second"`
+	ConfigFile          string   `json:"config_file"`
+	ExtendedProcessInfo bool     `json:"extended_process_info"`
+	SensitiveDataTypes  []string `json:"sensitive_data_types"`
 }
 
 func LoadConfig() (*Config, error) {
-    cfg := &Config{
-        ScanFiles:     true, // Default to scanning files
-        ScanProcesses: true, // Default to scanning processes
-    }
+	now := time.Now().UTC()
+	timestamp := now.Format("20060102-150405")
+	cfg := &Config{
+		StartPaths:         []string{"."},
+		ScanFiles:          true,
+		ScanProcesses:      true,
+		OutputFormat:       "json",
+		OutputFileName:     fmt.Sprintf("safnari-%s-%d.json", timestamp, now.Unix()),
+		ConcurrencyLevel:   runtime.NumCPU(),
+		NiceLevel:          "medium",
+		HashAlgorithms:     []string{"md5", "sha1", "sha256"},
+		SearchTerms:        []string{},
+		MaxFileSize:        10485760,
+		MaxOutputFileSize:  104857600,
+		LogLevel:           "info",
+		MaxIOPerSecond:     1000,
+		SensitiveDataTypes: []string{},
+	}
 
-    // Define command-line flags
-    startPath := flag.String("path", "", "Start path(s) for scanning (comma-separated)")
-    flag.BoolVar(&cfg.AllDrives, "all-drives", false, "Scan all local drives (Windows only)")
-    flag.BoolVar(&cfg.ScanFiles, "scan-files", true, "Enable or disable file scanning")
-    flag.BoolVar(&cfg.ScanProcesses, "scan-processes", true, "Enable or disable process scanning")
-    flag.StringVar(&cfg.OutputFormat, "format", "json", "Output format: json or csv")
-    flag.StringVar(&cfg.OutputFileName, "output", "output.json", "Output file name")
-    flag.IntVar(&cfg.ConcurrencyLevel, "concurrency", 4, "Concurrency level")
-    flag.StringVar(&cfg.NiceLevel, "nice", "medium", "Nice level: high, medium, low")
-    hashes := flag.String("hashes", "md5,sha1,sha256", "Hash algorithms to use (comma-separated)")
-    searches := flag.String("search", "", "Search terms (comma-separated)")
-    includes := flag.String("include", "", "Include patterns (comma-separated)")
-    excludes := flag.String("exclude", "", "Exclude patterns (comma-separated)")
-    flag.Int64Var(&cfg.MaxFileSize, "max-file-size", 10485760, "Maximum file size to process (bytes)")
-    flag.Int64Var(&cfg.MaxOutputFileSize, "max-output-file-size", 104857600, "Maximum output file size before rotation (bytes)")
-    flag.StringVar(&cfg.LogLevel, "log-level", "info", "Log level: debug, info, warn, error, fatal, panic")
-    flag.IntVar(&cfg.MaxIOPerSecond, "max-io-per-second", 1000, "Maximum disk I/O operations per second")
-    flag.StringVar(&cfg.ConfigFile, "config", "", "Path to JSON configuration file")
-    flag.BoolVar(&cfg.ExtendedProcessInfo, "extended-process-info", false, "Gather extended process information (requires elevated privileges)")
-    sensitiveDataTypes := flag.String("sensitive-data-types", "", "Sensitive data types to scan for (comma-separated)")
-    help := flag.Bool("help", false, "Display help message")
+	startPath := flag.String("path", strings.Join(cfg.StartPaths, ","), "Start path(s) for scanning (comma-separated)")
+	allDrives := flag.Bool("all-drives", cfg.AllDrives, "Scan all local drives (Windows only)")
+	scanFiles := flag.Bool("scan-files", cfg.ScanFiles, "Enable or disable file scanning")
+	scanProcesses := flag.Bool("scan-processes", cfg.ScanProcesses, "Enable or disable process scanning")
+	format := flag.String("format", cfg.OutputFormat, "Output format: json or csv")
+	output := flag.String("output", cfg.OutputFileName, "Output file name")
+	concurrency := flag.Int("concurrency", cfg.ConcurrencyLevel, "Concurrency level")
+	nice := flag.String("nice", cfg.NiceLevel, "Nice level: high, medium, low")
+	hashes := flag.String("hashes", strings.Join(cfg.HashAlgorithms, ","), "Hash algorithms to use (comma-separated)")
+	searches := flag.String("search", "", "Search terms (comma-separated)")
+	includes := flag.String("include", "", "Include patterns (comma-separated)")
+	excludes := flag.String("exclude", "", "Exclude patterns (comma-separated)")
+	maxFileSize := flag.Int64("max-file-size", cfg.MaxFileSize, "Maximum file size to process (bytes)")
+	maxOutputFileSize := flag.Int64("max-output-file-size", cfg.MaxOutputFileSize, "Maximum output file size before rotation (bytes)")
+	logLevel := flag.String("log-level", cfg.LogLevel, "Log level: debug, info, warn, error, fatal, panic")
+	maxIO := flag.Int("max-io-per-second", cfg.MaxIOPerSecond, "Maximum disk I/O operations per second")
+	configFile := flag.String("config", "", "Path to JSON configuration file")
+	extendedProcessInfo := flag.Bool("extended-process-info", cfg.ExtendedProcessInfo, "Gather extended process information (requires elevated privileges)")
+	sensitiveDataTypes := flag.String("sensitive-data-types", "", "Sensitive data types to scan for (comma-separated)")
 
-    flag.Parse()
+	flag.Usage = displayHelp
+	flag.Parse()
 
-    // Display help if requested or if no flags are provided
-    if *help || len(os.Args) == 1 {
-        displayHelp()
-        os.Exit(0)
-    }
+	if *configFile != "" {
+		cfg.ConfigFile = *configFile
+		if err := cfg.loadFromFile(cfg.ConfigFile); err != nil {
+			return nil, err
+		}
+	}
 
-    // Load configuration from file if specified
-    if cfg.ConfigFile != "" {
-        err := cfg.loadFromFile(cfg.ConfigFile)
-        if err != nil {
-            return nil, err
-        }
-    }
+	flag.Visit(func(f *flag.Flag) {
+		switch f.Name {
+		case "path":
+			cfg.StartPaths = parseCommaSeparated(*startPath)
+		case "all-drives":
+			cfg.AllDrives = *allDrives
+		case "scan-files":
+			cfg.ScanFiles = *scanFiles
+		case "scan-processes":
+			cfg.ScanProcesses = *scanProcesses
+		case "format":
+			cfg.OutputFormat = *format
+		case "output":
+			cfg.OutputFileName = *output
+		case "concurrency":
+			cfg.ConcurrencyLevel = *concurrency
+		case "nice":
+			cfg.NiceLevel = *nice
+		case "hashes":
+			cfg.HashAlgorithms = parseCommaSeparated(*hashes)
+		case "search":
+			cfg.SearchTerms = parseCommaSeparated(*searches)
+		case "include":
+			cfg.IncludePatterns = parseCommaSeparated(*includes)
+		case "exclude":
+			cfg.ExcludePatterns = parseCommaSeparated(*excludes)
+		case "max-file-size":
+			cfg.MaxFileSize = *maxFileSize
+		case "max-output-file-size":
+			cfg.MaxOutputFileSize = *maxOutputFileSize
+		case "log-level":
+			cfg.LogLevel = *logLevel
+		case "max-io-per-second":
+			cfg.MaxIOPerSecond = *maxIO
+		case "extended-process-info":
+			cfg.ExtendedProcessInfo = *extendedProcessInfo
+		case "sensitive-data-types":
+			cfg.SensitiveDataTypes = parseCommaSeparated(*sensitiveDataTypes)
+		}
+	})
 
-    // Override with command-line flags if set
-    cfg.overrideWithFlags()
+	if err := cfg.validate(); err != nil {
+		return nil, err
+	}
 
-    // Parse comma-separated values
-    cfg.StartPaths = parseCommaSeparated(*startPath)
-    cfg.HashAlgorithms = parseCommaSeparated(*hashes)
-    cfg.SearchTerms = parseCommaSeparated(*searches)
-    cfg.IncludePatterns = parseCommaSeparated(*includes)
-    cfg.ExcludePatterns = parseCommaSeparated(*excludes)
-    cfg.SensitiveDataTypes = parseCommaSeparated(*sensitiveDataTypes)
-
-    // Validate configuration
-    err := cfg.validate()
-    if err != nil {
-        return nil, err
-    }
-
-    return cfg, nil
+	return cfg, nil
 }
 
 func displayHelp() {
-    fmt.Println("Safnari - Advanced Cybersecurity Scanner")
-    fmt.Println()
-    fmt.Println("Usage:")
-    fmt.Println("  safnari.exe [options]")
-    fmt.Println()
-    fmt.Println("Options:")
-    flag.PrintDefaults()
-    fmt.Println()
-    fmt.Println("Examples:")
-    fmt.Println("  safnari.exe --path \"C:\\\"")
-    fmt.Println("  safnari.exe --path \"C:\\,D:\\\"")
-    fmt.Println("  safnari.exe --all-drives --scan-files=false --scan-processes=true")
+	fmt.Println("Safnari - Advanced Cybersecurity Scanner")
+	fmt.Println()
+	fmt.Println("Usage:")
+	fmt.Println("  safnari [options]")
+	fmt.Println()
+	fmt.Println("Options:")
+	flag.PrintDefaults()
+	fmt.Println()
+	fmt.Println("Examples:")
+	fmt.Println("  safnari --path \"/tmp\"")
+	fmt.Println("  safnari --path \"/home,/var\"")
+	fmt.Println("  safnari --all-drives --scan-files=false --scan-processes=true")
 }
 
 func (cfg *Config) loadFromFile(path string) error {
-    data, err := ioutil.ReadFile(path)
-    if err != nil {
-        return fmt.Errorf("could not read config file: %v", err)
-    }
-    err = json.Unmarshal(data, cfg)
-    if err != nil {
-        return fmt.Errorf("invalid config file format: %v", err)
-    }
-    return nil
-}
-
-func (cfg *Config) overrideWithFlags() {
-    flag.Visit(func(f *flag.Flag) {
-        switch f.Name {
-        case "path":
-            cfg.StartPaths = parseCommaSeparated(f.Value.String())
-        case "all-drives":
-            cfg.AllDrives = true
-        case "scan-files":
-            cfg.ScanFiles = parseBoolFlagValue(f)
-        case "scan-processes":
-            cfg.ScanProcesses = parseBoolFlagValue(f)
-        case "format":
-            cfg.OutputFormat = f.Value.String()
-        case "output":
-            cfg.OutputFileName = f.Value.String()
-        case "concurrency":
-            cfg.ConcurrencyLevel = getIntFlagValue(f)
-        case "nice":
-            cfg.NiceLevel = f.Value.String()
-        case "log-level":
-            cfg.LogLevel = f.Value.String()
-        case "max-file-size":
-            cfg.MaxFileSize = getInt64FlagValue(f)
-        case "max-output-file-size":
-            cfg.MaxOutputFileSize = getInt64FlagValue(f)
-        case "max-io-per-second":
-            cfg.MaxIOPerSecond = getIntFlagValue(f)
-        case "extended-process-info":
-            cfg.ExtendedProcessInfo = true
-        case "sensitive-data-types":
-            cfg.SensitiveDataTypes = parseCommaSeparated(f.Value.String())
-        }
-    })
+	data, err := ioutil.ReadFile(path)
+	if err != nil {
+		return fmt.Errorf("could not read config file: %v", err)
+	}
+	err = json.Unmarshal(data, cfg)
+	if err != nil {
+		return fmt.Errorf("invalid config file format: %v", err)
+	}
+	return nil
 }
 
 func (cfg *Config) validate() error {
-    if !cfg.ScanFiles && !cfg.ScanProcesses {
-        return fmt.Errorf("at least one of --scan-files or --scan-processes must be enabled")
-    }
-    if len(cfg.StartPaths) == 0 && !cfg.AllDrives && cfg.ScanFiles {
-        return fmt.Errorf("either start path(s) or --all-drives must be specified for file scanning")
-    }
-    if cfg.AllDrives && runtime.GOOS != "windows" {
-        return fmt.Errorf("--all-drives flag is only supported on Windows")
-    }
-    if cfg.OutputFormat != "json" && cfg.OutputFormat != "csv" {
-        return fmt.Errorf("invalid output format: %s", cfg.OutputFormat)
-    }
-    if cfg.ConcurrencyLevel <= 0 {
-        return fmt.Errorf("concurrency level must be positive")
-    }
-    if cfg.NiceLevel != "high" && cfg.NiceLevel != "medium" && cfg.NiceLevel != "low" {
-        return fmt.Errorf("invalid nice level: %s", cfg.NiceLevel)
-    }
-    if cfg.LogLevel != "debug" && cfg.LogLevel != "info" && cfg.LogLevel != "warn" &&
-        cfg.LogLevel != "error" && cfg.LogLevel != "fatal" && cfg.LogLevel != "panic" {
-        return fmt.Errorf("invalid log level: %s", cfg.LogLevel)
-    }
-    return nil
+	if !cfg.ScanFiles && !cfg.ScanProcesses {
+		return fmt.Errorf("at least one of --scan-files or --scan-processes must be enabled")
+	}
+	if len(cfg.StartPaths) == 0 && !cfg.AllDrives && cfg.ScanFiles {
+		return fmt.Errorf("either start path(s) or --all-drives must be specified for file scanning")
+	}
+	if cfg.AllDrives && runtime.GOOS != "windows" {
+		return fmt.Errorf("--all-drives flag is only supported on Windows")
+	}
+	if cfg.OutputFormat != "json" && cfg.OutputFormat != "csv" {
+		return fmt.Errorf("invalid output format: %s", cfg.OutputFormat)
+	}
+	if cfg.ConcurrencyLevel <= 0 {
+		return fmt.Errorf("concurrency level must be positive")
+	}
+	if cfg.NiceLevel != "high" && cfg.NiceLevel != "medium" && cfg.NiceLevel != "low" {
+		return fmt.Errorf("invalid nice level: %s", cfg.NiceLevel)
+	}
+	if cfg.LogLevel != "debug" && cfg.LogLevel != "info" && cfg.LogLevel != "warn" &&
+		cfg.LogLevel != "error" && cfg.LogLevel != "fatal" && cfg.LogLevel != "panic" {
+		return fmt.Errorf("invalid log level: %s", cfg.LogLevel)
+	}
+	return nil
 }
 
 func parseCommaSeparated(input string) []string {
-    if input == "" {
-        return []string{}
-    }
-    items := strings.Split(input, ",")
-    for i, item := range items {
-        items[i] = strings.TrimSpace(item)
-    }
-    return items
-}
-
-func getIntFlagValue(f *flag.Flag) int {
-    value, err := strconv.Atoi(f.Value.String())
-    if err != nil {
-        return 0
-    }
-    return value
-}
-
-func getInt64FlagValue(f *flag.Flag) int64 {
-    value, err := strconv.ParseInt(f.Value.String(), 10, 64)
-    if err != nil {
-        return 0
-    }
-    return value
-}
-
-func parseBoolFlagValue(f *flag.Flag) bool {
-    value, err := strconv.ParseBool(f.Value.String())
-    if err != nil {
-        return false
-    }
-    return value
+	if input == "" {
+		return []string{}
+	}
+	items := strings.Split(input, ",")
+	for i, item := range items {
+		items[i] = strings.TrimSpace(item)
+	}
+	return items
 }

--- a/src/config/config_test.go
+++ b/src/config/config_test.go
@@ -1,7 +1,6 @@
 package config
 
 import (
-	"flag"
 	"os"
 	"runtime"
 	"testing"
@@ -14,23 +13,6 @@ func TestParseCommaSeparated(t *testing.T) {
 	}
 	if res := parseCommaSeparated(""); len(res) != 0 {
 		t.Fatalf("expected empty slice")
-	}
-}
-
-func TestFlagParsers(t *testing.T) {
-	fs := flag.NewFlagSet("test", flag.ContinueOnError)
-	fs.Int("i", 5, "")
-	fs.Int64("i64", 10, "")
-	fs.Bool("b", true, "")
-	fs.Parse([]string{"-i=7", "-i64=20", "-b=false"})
-	if getIntFlagValue(fs.Lookup("i")) != 7 {
-		t.Fatal("int parse failed")
-	}
-	if getInt64FlagValue(fs.Lookup("i64")) != 20 {
-		t.Fatal("int64 parse failed")
-	}
-	if parseBoolFlagValue(fs.Lookup("b")) {
-		t.Fatal("bool parse failed")
 	}
 }
 


### PR DESCRIPTION
## Summary
- refactor configuration loader to rely on standard flag usage with defaults
- default to scanning current directory and using all CPUs for concurrency
- update documentation for new flag behavior and defaults
- disable default search terms and produce timestamped output filename

## Testing
- `make lint`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_68b91ab0c3888333a38de6cf43ea7398