### PR TITLE
Add fuzzy hashing and network data collection

### DIFF
--- a/src/go.mod
+++ b/src/go.mod
@@ -6,6 +6,7 @@ toolchain go1.24.3
 
 require (
 	github.com/djherbis/times v1.6.0
+	github.com/glaslos/ssdeep v0.4.0
 	github.com/h2non/filetype v1.1.3
 	github.com/pdfcpu/pdfcpu v0.11.0
 	github.com/rwcarlsen/goexif v0.0.0-20190401172101-9e8deecbddbd

--- a/src/go.sum
+++ b/src/go.sum
@@ -5,6 +5,8 @@ github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/djherbis/times v1.6.0 h1:w2ctJ92J8fBvWPxugmXIv7Nz7Q3iDMKNx9v5ocVH20c=
 github.com/djherbis/times v1.6.0/go.mod h1:gOHeRAz2h+VJNZ5Gmc/o7iD9k4wW7NMVqieYCY99oc0=
+github.com/glaslos/ssdeep v0.4.0 h1:w9PtY1HpXbWLYgrL/rvAVkj2ZAMOtDxoGKcBHcUFCLs=
+github.com/glaslos/ssdeep v0.4.0/go.mod h1:il4NniltMO8eBtU7dqoN+HVJ02gXxbpbUfkcyUvNtG0=
 github.com/go-ole/go-ole v1.2.6/go.mod h1:pprOEPIfldk/42T2oK7lQ4v4JSDwmV0As9GaiUsvbm0=
 github.com/go-ole/go-ole v1.3.0 h1:Dt6ye7+vXGIKZ7Xtk4s6/xVdGDQynvom7xCFEdWr6uE=
 github.com/go-ole/go-ole v1.3.0/go.mod h1:5LS6F96DhAwUc7C+1HLexzMXY1xGRSryjyPPKW6zv78=

--- a/src/hasher/hasher.go
+++ b/src/hasher/hasher.go
@@ -1,57 +1,62 @@
 package hasher
 
 import (
-    "crypto/md5"
-    "crypto/sha1"
-    "crypto/sha256"
-    "fmt"
-    "io"
-    "os"
+	"crypto/md5"
+	"crypto/sha1"
+	"crypto/sha256"
+	"fmt"
+	"io"
+	"os"
 
-    "safnari/logger"
+	"github.com/glaslos/ssdeep"
+	"safnari/logger"
 )
 
 func ComputeHashes(path string, algorithms []string) map[string]string {
-    hashes := make(map[string]string)
+	hashes := make(map[string]string)
 
-    file, err := os.Open(path)
-    if err != nil {
-        logger.Warnf("Failed to open file for hashing %s: %v", path, err)
-        return hashes
-    }
-    defer file.Close()
+	file, err := os.Open(path)
+	if err != nil {
+		logger.Warnf("Failed to open file for hashing %s: %v", path, err)
+		return hashes
+	}
+	defer file.Close()
 
-    for _, algo := range algorithms {
-        if hashValue := computeHash(file, algo); hashValue != "" {
-            hashes[algo] = hashValue
-        }
-        // Reset file pointer
-        file.Seek(0, io.SeekStart)
-    }
+	for _, algo := range algorithms {
+		if hashValue := computeHash(file, algo); hashValue != "" {
+			hashes[algo] = hashValue
+		}
+		// Reset file pointer
+		file.Seek(0, io.SeekStart)
+	}
 
-    return hashes
+	return hashes
 }
 
 func computeHash(file *os.File, algorithm string) string {
-    var hashValue string
-    switch algorithm {
-    case "md5":
-        h := md5.New()
-        if _, err := io.Copy(h, file); err == nil {
-            hashValue = fmt.Sprintf("%x", h.Sum(nil))
-        }
-    case "sha1":
-        h := sha1.New()
-        if _, err := io.Copy(h, file); err == nil {
-            hashValue = fmt.Sprintf("%x", h.Sum(nil))
-        }
-    case "sha256":
-        h := sha256.New()
-        if _, err := io.Copy(h, file); err == nil {
-            hashValue = fmt.Sprintf("%x", h.Sum(nil))
-        }
-    default:
-        logger.Warnf("Unsupported hash algorithm: %s", algorithm)
-    }
-    return hashValue
+	var hashValue string
+	switch algorithm {
+	case "md5":
+		h := md5.New()
+		if _, err := io.Copy(h, file); err == nil {
+			hashValue = fmt.Sprintf("%x", h.Sum(nil))
+		}
+	case "sha1":
+		h := sha1.New()
+		if _, err := io.Copy(h, file); err == nil {
+			hashValue = fmt.Sprintf("%x", h.Sum(nil))
+		}
+	case "sha256":
+		h := sha256.New()
+		if _, err := io.Copy(h, file); err == nil {
+			hashValue = fmt.Sprintf("%x", h.Sum(nil))
+		}
+	case "ssdeep":
+		if hash, err := ssdeep.FuzzyFile(file); err == nil {
+			hashValue = hash
+		}
+	default:
+		logger.Warnf("Unsupported hash algorithm: %s", algorithm)
+	}
+	return hashValue
 }

--- a/src/systeminfo/systeminfo_stub.go
+++ b/src/systeminfo/systeminfo_stub.go
@@ -23,3 +23,8 @@ func gatherInstalledApps(sysInfo *SystemInfo) error {
 	// Stub implementation
 	return nil
 }
+
+func gatherRunningServices(sysInfo *SystemInfo) error {
+	// Stub implementation
+	return nil
+}

--- a/src/systeminfo/systeminfo_test.go
+++ b/src/systeminfo/systeminfo_test.go
@@ -32,3 +32,27 @@ func TestGatherRunningProcesses(t *testing.T) {
 		t.Fatalf("gather extended: %v", err)
 	}
 }
+
+func TestGatherNetworkInterfaces(t *testing.T) {
+	sys := &SystemInfo{}
+	if err := gatherNetworkInterfaces(sys); err != nil {
+		t.Fatalf("interfaces: %v", err)
+	}
+	if len(sys.NetworkInterfaces) == 0 {
+		t.Fatal("expected at least one interface")
+	}
+}
+
+func TestGatherOpenConnections(t *testing.T) {
+	sys := &SystemInfo{}
+	if err := gatherOpenConnections(sys); err != nil {
+		t.Fatalf("connections: %v", err)
+	}
+}
+
+func TestGatherRunningServices(t *testing.T) {
+	sys := &SystemInfo{}
+	if err := gatherRunningServices(sys); err != nil {
+		t.Fatalf("services: %v", err)
+	}
+}

--- a/src/systeminfo/systeminfo_windows.go
+++ b/src/systeminfo/systeminfo_windows.go
@@ -8,6 +8,7 @@ import (
 	"os/exec"
 	"strings"
 
+	"github.com/shirou/gopsutil/v3/winservices"
 	"golang.org/x/sys/windows/registry"
 )
 
@@ -85,6 +86,21 @@ func gatherInstalledApps(sysInfo *SystemInfo) error {
 			}
 			appKey.Close()
 		}
+	}
+	return nil
+}
+
+func gatherRunningServices(sysInfo *SystemInfo) error {
+	services, err := winservices.ListServices()
+	if err != nil {
+		return fmt.Errorf("failed to list services: %v", err)
+	}
+	for _, s := range services {
+		status, err := s.Status()
+		if err != nil {
+			continue
+		}
+		sysInfo.RunningServices = append(sysInfo.RunningServices, ServiceInfo{Name: s.Name, Status: status})
 	}
 	return nil
 }


### PR DESCRIPTION
## Summary
- add `--fuzzy-hash` flag to enable ssdeep fuzzy hashing
- collect network interfaces, open connections, and running services

## Testing
- `make lint`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_68b91f28bc5c833394e37b2abeb7aef4