### PR TITLE
Fix Windows service status handling and trace startup guard

### DIFF
--- a/src/cmd/main.go
+++ b/src/cmd/main.go
@@ -19,8 +19,9 @@ import (
 func main() {
 	if err := tracing.Start(); err != nil {
 		fmt.Fprintf(os.Stderr, "Failed to start trace: %v\n", err)
+	} else {
+		defer tracing.Stop()
 	}
-	defer tracing.Stop()
 
 	// Initialize configuration
 	cfg, err := config.LoadConfig()


### PR DESCRIPTION
## Summary
- convert Windows service status to string and map svc.State values
- only defer trace shutdown when tracing starts successfully

## Testing
- `make lint`
- `make test`
- `cd src && GOOS=windows GOARCH=amd64 go build ./...`


------
https://chatgpt.com/codex/tasks/task_e_68b986f25fd08333800098c3a3d01a7f