### PR TITLE
build: add arm64 targets

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,8 +24,17 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        goos: [linux, darwin, windows]
-        goarch: [amd64]
+        include:
+          - goos: linux
+            goarch: amd64
+          - goos: linux
+            goarch: arm64
+          - goos: darwin
+            goarch: amd64
+          - goos: darwin
+            goarch: arm64
+          - goos: windows
+            goarch: amd64
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v4

--- a/Makefile
+++ b/Makefile
@@ -3,12 +3,20 @@ GOARCH ?= $(shell go env GOARCH)
 EXT := $(if $(filter windows,$(GOOS)),.exe,)
 BIN_DIR := bin
 BIN := $(BIN_DIR)/safnari-$(GOOS)-$(GOARCH)$(EXT)
+PLATFORMS := linux/amd64 linux/arm64 darwin/amd64 darwin/arm64 windows/amd64
 
-.PHONY: build test lint clean
+.PHONY: build build-all test lint clean
 
 build:
 	@mkdir -p $(BIN_DIR)
 	cd src && GOOS=$(GOOS) GOARCH=$(GOARCH) go build -o ../$(BIN) ./cmd
+
+build-all:
+	@mkdir -p $(BIN_DIR)
+	@for platform in $(PLATFORMS); do \
+		os=$${platform%/*}; arch=$${platform#*/}; \
+		GOOS=$$os GOARCH=$$arch $(MAKE) build; \
+	done
 
 test:
 	cd src && go test ./...

--- a/README.md
+++ b/README.md
@@ -24,6 +24,22 @@ make build
 
 The compiled binary will be located in the `bin` directory.
 
+To cross-compile for other platforms, set `GOOS` and `GOARCH`:
+
+```sh
+# macOS Apple Silicon
+GOOS=darwin GOARCH=arm64 make build
+
+# Linux ARM64
+GOOS=linux GOARCH=arm64 make build
+```
+
+You can build binaries for all supported targets at once with:
+
+```sh
+make build-all
+```
+
 To include runtime tracing for debugging and performance analysis, build with
 the `trace` tag:
 


### PR DESCRIPTION
## Summary
- add build-all target for multi-platform binaries
- cross-compile macOS and Linux arm64 in CI
- document arm64 build commands

## Testing
- `make lint`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_68b9f06c03ac83338af4616e479fb3bb