### PR TITLE
Add version flag and GitHub update check

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,14 @@ make build
 
 The compiled binary will be located in the `bin` directory.
 
+Safnari embeds its version at build time. To set the version string, pass a
+`-ldflags` option:
+
+```sh
+cd src
+go build -ldflags "-X safnari/version.Version=v1.0.2" -o ../bin/safnari ./cmd
+```
+
 To cross-compile for other platforms, set `GOOS` and `GOARCH`:
 
 ```sh
@@ -71,6 +79,10 @@ This will scan `/home/user`, compute SHA-256 hashes, search for the term
 `password`, and write results to a file such as
 `safnari-20240130-150405-1706625005.json` unless an alternate output filename
 is provided.
+
+Use `--version` to print the embedded version. On startup Safnari checks the
+latest GitHub release and logs a message if an update, including any noted
+security fixes, is available.
 
 ## Documentation
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -34,6 +34,13 @@ cd src
 go build -tags trace -o ../bin/safnari-trace ./cmd
 ```
 
+To embed a version string during compilation, use an `-ldflags` parameter:
+
+```sh
+cd src
+go build -ldflags "-X safnari/version.Version=v1.0.2" -o ../bin/safnari ./cmd
+```
+
 ## Usage
 
 Run the compiled binary with desired flags. Running with `-h` prints all options.
@@ -41,6 +48,10 @@ Run the compiled binary with desired flags. Running with `-h` prints all options
 ```sh
 ./bin/safnari-$(go env GOOS)-$(go env GOARCH) --help
 ```
+
+Use `--version` to display the current version. On startup Safnari checks the latest
+GitHub release and logs a message if a newer version, including any security fixes,
+is available.
 
 ## Configuration
 

--- a/src/cmd/main.go
+++ b/src/cmd/main.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"os/signal"
+	"strings"
 	"syscall"
 	"time"
 
@@ -14,6 +15,8 @@ import (
 	"safnari/scanner"
 	"safnari/systeminfo"
 	"safnari/tracing"
+	"safnari/update"
+	"safnari/version"
 )
 
 func main() {
@@ -32,6 +35,14 @@ func main() {
 
 	// Initialize logger
 	logger.Init(cfg.LogLevel)
+
+	if latest, notes, newer, err := update.CheckForUpdate(version.Version); err == nil && newer {
+		if strings.Contains(strings.ToLower(notes), "security") {
+			logger.Warnf("Update available: %s -> %s (security fixes included)", version.Version, latest)
+		} else {
+			logger.Infof("Update available: %s -> %s", version.Version, latest)
+		}
+	}
 
 	// Record start time
 	startTime := time.Now()

--- a/src/config/config.go
+++ b/src/config/config.go
@@ -5,9 +5,12 @@ import (
 	"flag"
 	"fmt"
 	"io/ioutil"
+	"os"
 	"runtime"
 	"strings"
 	"time"
+
+	"safnari/version"
 )
 
 type Config struct {
@@ -73,9 +76,15 @@ func LoadConfig() (*Config, error) {
 	extendedProcessInfo := flag.Bool("extended-process-info", cfg.ExtendedProcessInfo, "Gather extended process information (requires elevated privileges)")
 	sensitiveDataTypes := flag.String("sensitive-data-types", "", "Sensitive data types to scan for (comma-separated)")
 	fuzzyHash := flag.Bool("fuzzy-hash", cfg.FuzzyHash, "Enable fuzzy hashing (ssdeep)")
+	showVersion := flag.Bool("version", false, "Print version and exit")
 
 	flag.Usage = displayHelp
 	flag.Parse()
+
+	if *showVersion {
+		fmt.Printf("Safnari version %s\n", version.Version)
+		os.Exit(0)
+	}
 
 	if *configFile != "" {
 		cfg.ConfigFile = *configFile

--- a/src/update/update.go
+++ b/src/update/update.go
@@ -1,0 +1,41 @@
+package update
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"strings"
+	"time"
+)
+
+type releaseInfo struct {
+	TagName string `json:"tag_name"`
+	Body    string `json:"body"`
+}
+
+const releaseURL = "https://api.github.com/repos/ProvisioInsights/Safnari/releases/latest"
+
+func CheckForUpdate(current string) (string, string, bool, error) {
+	return checkForUpdateURL(current, releaseURL)
+}
+
+func checkForUpdateURL(current, url string) (string, string, bool, error) {
+	client := &http.Client{Timeout: 5 * time.Second}
+	resp, err := client.Get(url)
+	if err != nil {
+		return "", "", false, err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return "", "", false, fmt.Errorf("unexpected status: %s", resp.Status)
+	}
+	var info releaseInfo
+	if err := json.NewDecoder(resp.Body).Decode(&info); err != nil {
+		return "", "", false, err
+	}
+	latest := strings.TrimPrefix(info.TagName, "v")
+	if latest != current {
+		return latest, info.Body, true, nil
+	}
+	return latest, "", false, nil
+}

--- a/src/update/update_test.go
+++ b/src/update/update_test.go
@@ -1,0 +1,45 @@
+package update
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestCheckForUpdate(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"tag_name":"v1.2.0","body":"security fix"}`))
+	}))
+	defer ts.Close()
+
+	latest, notes, newer, err := checkForUpdateURL("1.0.0", ts.URL)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !newer {
+		t.Fatalf("expected update available")
+	}
+	if latest != "1.2.0" {
+		t.Fatalf("unexpected latest version: %s", latest)
+	}
+	if notes != "security fix" {
+		t.Fatalf("unexpected release notes: %s", notes)
+	}
+}
+
+func TestCheckForUpdateNoUpdate(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"tag_name":"v1.2.0","body":""}`))
+	}))
+	defer ts.Close()
+
+	_, _, newer, err := checkForUpdateURL("1.2.0", ts.URL)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if newer {
+		t.Fatalf("did not expect update")
+	}
+}

--- a/src/version/version.go
+++ b/src/version/version.go
@@ -1,0 +1,5 @@
+package version
+
+// Version is the current Safnari version. It is set at build time via
+// `-ldflags "-X safnari/version.Version=v1.0.0"`.
+var Version = "dev"


### PR DESCRIPTION
## Summary
- add build-time `Version` variable and expose with `--version`
- query GitHub releases at startup and log if a newer version exists, highlighting security fixes
- document version embedding and automatic update checks

## Testing
- `make lint`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_68ba0660ead48333a7275bc0450bc11f