### PR TITLE
Add fmt target and document development workflow

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ BIN_DIR := bin
 BIN := $(BIN_DIR)/safnari-$(GOOS)-$(GOARCH)$(EXT)
 PLATFORMS := linux/amd64 linux/arm64 darwin/amd64 darwin/arm64 windows/amd64
 
-.PHONY: build build-all test lint clean
+.PHONY: build build-all fmt test lint clean
 
 build:
 	@mkdir -p $(BIN_DIR)
@@ -23,6 +23,9 @@ test:
 
 lint:
 	cd src && go vet ./...
+
+fmt:
+	cd src && gofmt -w .
 
 clean:
 	rm -rf $(BIN_DIR)

--- a/README.md
+++ b/README.md
@@ -88,6 +88,16 @@ security fixes, is available.
 
 See the [docs](docs/README.md) directory for extended guides and additional examples.
 
+## Development
+
+Before submitting changes, format the Go source and run the linters and tests:
+
+```sh
+make fmt
+make lint
+make test
+```
+
 ## Contributing
 
 Contributions to Safnari are always welcome! Feel free to open issues or submit pull requests to help improve the project.

--- a/docs/README.md
+++ b/docs/README.md
@@ -41,6 +41,16 @@ cd src
 go build -ldflags "-X safnari/version.Version=v1.0.2" -o ../bin/safnari ./cmd
 ```
 
+## Development
+
+Format, lint, and test the codebase before submitting patches:
+
+```sh
+make fmt
+make lint
+make test
+```
+
 ## Usage
 
 Run the compiled binary with desired flags. Running with `-h` prints all options.


### PR DESCRIPTION
## Summary
- add `fmt` target to Makefile for running `gofmt`
- document formatting, linting, and testing steps for contributors

## Testing
- `make lint`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_68ba3b9d10248333a66c6d183b955530