### PR TITLE
chore: upgrade to Go 1.24

### DIFF
--- a/src/go.mod
+++ b/src/go.mod
@@ -1,6 +1,6 @@
 module safnari
 
-go 1.23.0
+go 1.24.0
 
 toolchain go1.24.3
 

--- a/src/metadata/metadata.go
+++ b/src/metadata/metadata.go
@@ -3,6 +3,7 @@ package metadata
 import (
 	"archive/zip"
 	"encoding/xml"
+	"maps"
 	"os"
 	"time"
 
@@ -16,19 +17,13 @@ func ExtractMetadata(path string, mimeType string) map[string]interface{} {
 	switch mimeType {
 	case "image/jpeg", "image/png":
 		meta := extractImageMetadata(path)
-		for k, v := range meta {
-			metadata[k] = v
-		}
+		maps.Copy(metadata, meta)
 	case "application/pdf":
 		meta := extractPDFMetadata(path)
-		for k, v := range meta {
-			metadata[k] = v
-		}
+		maps.Copy(metadata, meta)
 	case "application/vnd.openxmlformats-officedocument.wordprocessingml.document":
 		meta := extractDOCXMetadata(path)
-		for k, v := range meta {
-			metadata[k] = v
-		}
+		maps.Copy(metadata, meta)
 	default:
 		// Unsupported MIME type for metadata extraction
 	}

--- a/src/output/output_test.go
+++ b/src/output/output_test.go
@@ -73,7 +73,7 @@ func TestWriteDataConcurrent(t *testing.T) {
 	}
 
 	var wg sync.WaitGroup
-	for i := 0; i < 5; i++ {
+	for i := range 5 {
 		wg.Add(1)
 		go func(i int) {
 			defer wg.Done()
@@ -87,7 +87,7 @@ func TestWriteDataConcurrent(t *testing.T) {
 	if err != nil {
 		t.Fatalf("read: %v", err)
 	}
-	for i := 0; i < 5; i++ {
+	for i := range 5 {
 		if !strings.Contains(string(content), "\"path\": "+strconv.Itoa(i)) {
 			t.Fatalf("missing entry %d", i)
 		}

--- a/src/scanner/scanner.go
+++ b/src/scanner/scanner.go
@@ -118,7 +118,7 @@ func ScanFiles(ctx context.Context, cfg *config.Config, metrics *output.Metrics,
 	}()
 
 	// Start worker pool
-	for i := 0; i < cfg.ConcurrencyLevel; i++ {
+	for range cfg.ConcurrencyLevel {
 		wg.Add(1)
 		go func() {
 			defer wg.Done()


### PR DESCRIPTION
## Summary
- upgrade module to Go 1.24
- replace manual map copies with maps.Copy
- use range-over-integer loops in scanner and tests

## Testing
- `make lint`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_68ba630ee68883338380458e5816f8aa