### PR TITLE
fix: stabilize benchmark workflow on macOS and Windows

### DIFF
--- a/.github/workflows/performance.yml
+++ b/.github/workflows/performance.yml
@@ -25,9 +25,11 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v4
         with:
-          go-version: '1.22'
-      - run: go test -run=^$ -bench=. -benchmem ./... | tee benchmark.txt
+          go-version-file: src/go.mod
+          cache-dependency-path: src/go.sum
+      - run: go test -run '^$' -bench=. -benchmem ./... | tee benchmark.txt
         working-directory: src
+        shell: bash
       - uses: actions/upload-artifact@v4
         with:
           name: benchmarks-${{ matrix.goos }}-${{ matrix.goarch }}


### PR DESCRIPTION
## Summary
- fix benchmark workflow to use Go version and cache from `src` module
- run benchmarks with bash for cross-platform compatibility

## Testing
- `make lint`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_68ba6904a2a08333945cf17a7c2601f8