### PR TITLE
chore: configure permissions for defender workflow

### DIFF
--- a/.github/workflows/defender-for-devops.yml
+++ b/.github/workflows/defender-for-devops.yml
@@ -26,10 +26,17 @@ on:
   schedule:
     - cron: '22 7 * * 5'
 
+permissions:
+  contents: read
+
 jobs:
   MSDO:
     # currently only windows latest is supported
     runs-on: windows-latest
+    permissions:
+      contents: read
+      security-events: write
+      id-token: write
 
     steps:
     - uses: actions/checkout@v4


### PR DESCRIPTION
## Summary
- grant minimal default permissions and add `id-token` & `security-events` write access for the Microsoft Defender workflow

## Testing
- `make lint`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_68bb0fa938488333926102a4bcdc8a2f