### PR TITLE
Add customizable sensitive data patterns with credit card validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ configuration flags for filtering, hashing, and output control.
 - Scan files across specified paths or all drives
 - Calculate file hashes (MD5, SHA1, SHA256)
 - Extract metadata from images (EXIF), PDFs, and DOCX documents
- - Detect sensitive data patterns such as emails, credit cards (with Luhn validation), AWS keys, JWT tokens, street addresses, IBANs, UK National Insurance numbers, EU VAT IDs, India Aadhaar numbers, China resident IDs, and user-defined regexes. Users can scan only selected types with `--include-sensitive-data-types` or skip some with `--exclude-sensitive-data-types`.
+ - Detect sensitive data patterns such as emails, credit cards (with Luhn validation), AWS keys, JWT tokens, street addresses, IBANs, UK National Insurance numbers, EU VAT IDs, India Aadhaar numbers, China resident IDs, and user-defined regexes via the `--custom-patterns` JSON flag. Users can scan only selected types with `--include-sensitive-data-types` or skip some with `--exclude-sensitive-data-types`.
 - Output results with metrics in JSON format
 
 ## Installation
@@ -74,6 +74,11 @@ the current working directory using a concurrency level equal to the number of
 logical CPUs. It does not search for any strings or sensitive data types unless
 explicitly requested and writes results to a timestamped file named
 `safnari-<human-readable>-<unix>.json`.
+
+If only `--exclude-sensitive-data-types` is supplied, Safnari scans all built-in patterns except
+those excluded. When both include and exclude lists are provided, the exclusion list removes types
+from the inclusion list. Custom regex patterns can be added with `--custom-patterns` using a JSON
+object mapping names to regexes.
 
 ### Default flags
 

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ configuration flags for filtering, hashing, and output control.
 - Scan files across specified paths or all drives
 - Calculate file hashes (MD5, SHA1, SHA256)
 - Extract metadata from images (EXIF), PDFs, and DOCX documents
-- Detect sensitive data patterns such as emails and credit cards
+- Detect sensitive data patterns such as emails, credit cards (with Luhn validation), AWS keys, JWT tokens, street addresses, and user-defined regexes
 - Output results with metrics in JSON format
 
 ## Installation

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ configuration flags for filtering, hashing, and output control.
 - Scan files across specified paths or all drives
 - Calculate file hashes (MD5, SHA1, SHA256)
 - Extract metadata from images (EXIF), PDFs, and DOCX documents
-- Detect sensitive data patterns such as emails, credit cards (with Luhn validation), AWS keys, JWT tokens, street addresses, and user-defined regexes
+- Detect sensitive data patterns such as emails, credit cards (with Luhn validation), AWS keys, JWT tokens, street addresses, IBANs, UK National Insurance numbers, EU VAT IDs, India Aadhaar numbers, China resident IDs, and user-defined regexes. Patterns can be enabled or disabled individually.
 - Output results with metrics in JSON format
 
 ## Installation
@@ -98,6 +98,7 @@ Running Safnari without any flags applies these defaults:
 - `--config`: none
 - `--extended-process-info`: `false`
 - `--sensitive-data-types`: none
+- `--exclude-sensitive-data-types`: none
 - `--fuzzy-hash`: `false`
 - `--delta-scan`: `false`
 - `--last-scan-file`: `.safnari_last_scan`

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ configuration flags for filtering, hashing, and output control.
 - Scan files across specified paths or all drives
 - Calculate file hashes (MD5, SHA1, SHA256)
 - Extract metadata from images (EXIF), PDFs, and DOCX documents
-- Detect sensitive data patterns such as emails, credit cards (with Luhn validation), AWS keys, JWT tokens, street addresses, IBANs, UK National Insurance numbers, EU VAT IDs, India Aadhaar numbers, China resident IDs, and user-defined regexes. Patterns can be enabled or disabled individually.
+ - Detect sensitive data patterns such as emails, credit cards (with Luhn validation), AWS keys, JWT tokens, street addresses, IBANs, UK National Insurance numbers, EU VAT IDs, India Aadhaar numbers, China resident IDs, and user-defined regexes. Users can scan only selected types with `--include-sensitive-data-types` or skip some with `--exclude-sensitive-data-types`.
 - Output results with metrics in JSON format
 
 ## Installation
@@ -97,7 +97,7 @@ Running Safnari without any flags applies these defaults:
 - `--max-io-per-second`: `1000`
 - `--config`: none
 - `--extended-process-info`: `false`
-- `--sensitive-data-types`: none
+- `--include-sensitive-data-types`: none
 - `--exclude-sensitive-data-types`: none
 - `--fuzzy-hash`: `false`
 - `--delta-scan`: `false`

--- a/docs/README.md
+++ b/docs/README.md
@@ -14,8 +14,8 @@ This directory contains extended documentation for Safnari.
 
 Safnari collects file metadata and system information from user specified paths. It can hash files,
 search for sensitive strings such as emails, credit cards, AWS keys, JWT tokens, street addresses,
-IBANs, UK National Insurance numbers, EU VAT IDs, India Aadhaar numbers,
-China resident IDs, and custom regex patterns. Scan only selected types with
+IBANs, UK National Insurance numbers, EU VAT IDs, India Aadhaar numbers, China resident IDs, and
+custom regex patterns supplied via the `--custom-patterns` JSON flag. Scan only selected types with
 `--include-sensitive-data-types` or skip some with `--exclude-sensitive-data-types`.
 Safnari also reports system details such as
 running processes. The goal of this documentation is to provide deeper
@@ -96,14 +96,18 @@ Safnari accepts the following flags. Each description lists the default value in
   to include when scanning. Use `all` to include all built-in patterns (default: none).
 - `--exclude-sensitive-data-types`: Comma-separated list of sensitive data types
   to skip when scanning (default: none).
-- `--custom-patterns`: Custom sensitive data patterns as name:regex pairs
-  (default: none).
+- `--custom-patterns`: Custom sensitive data patterns as a JSON object mapping
+  names to regexes (default: none).
 - `--fuzzy-hash`: Enable fuzzy hashing (ssdeep) (default: `false`).
 - `--delta-scan`: Only scan files modified since the last run (default: `false`).
 - `--last-scan-file`: Path to timestamp file for delta scans (default: `.safnari_last_scan`).
 - `--last-scan`: Timestamp of last scan in RFC3339 format (e.g.,
   `2006-01-02T15:04:05Z`) (default: none).
 - `--version`: Print version and exit.
+
+If only `--exclude-sensitive-data-types` is provided, Safnari scans all built-in
+patterns except those excluded. When both include and exclude flags are set, the
+exclusion list removes types from the inclusion list.
 
 See `./bin/safnari --help` for detailed usage information.
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -13,7 +13,8 @@ This directory contains extended documentation for Safnari.
 ## Overview
 
 Safnari collects file metadata and system information from user specified paths. It can hash files,
-search for sensitive strings, and report system details such as running processes. The goal of this
+search for sensitive strings such as emails, credit cards, AWS keys, JWT tokens, street addresses,
+and custom regex patterns, and report system details such as running processes. The goal of this
 documentation is to provide deeper explanations and examples than the top level README.
 
 ## Building
@@ -89,6 +90,8 @@ Safnari accepts the following flags. Each description lists the default value in
   elevated privileges) (default: `false`).
 - `--sensitive-data-types`: Comma-separated list of sensitive data types to scan
   for (default: none).
+- `--custom-patterns`: Custom sensitive data patterns as name:regex pairs
+  (default: none).
 - `--fuzzy-hash`: Enable fuzzy hashing (ssdeep) (default: `false`).
 - `--delta-scan`: Only scan files modified since the last run (default: `false`).
 - `--last-scan-file`: Path to timestamp file for delta scans (default: `.safnari_last_scan`).

--- a/docs/README.md
+++ b/docs/README.md
@@ -15,8 +15,9 @@ This directory contains extended documentation for Safnari.
 Safnari collects file metadata and system information from user specified paths. It can hash files,
 search for sensitive strings such as emails, credit cards, AWS keys, JWT tokens, street addresses,
 IBANs, UK National Insurance numbers, EU VAT IDs, India Aadhaar numbers,
-China resident IDs, and custom regex patterns. Sensitive data checks can be
-enabled or disabled individually. Safnari also reports system details such as
+China resident IDs, and custom regex patterns. Scan only selected types with
+`--include-sensitive-data-types` or skip some with `--exclude-sensitive-data-types`.
+Safnari also reports system details such as
 running processes. The goal of this documentation is to provide deeper
 explanations and examples than the top level README.
 
@@ -91,8 +92,8 @@ Safnari accepts the following flags. Each description lists the default value in
 - `--config`: Path to JSON configuration file (default: none).
 - `--extended-process-info`: Gather extended process information (requires
   elevated privileges) (default: `false`).
-- `--sensitive-data-types`: Comma-separated list of sensitive data types to scan
-  for. Use `all` to include all built-in patterns (default: none).
+- `--include-sensitive-data-types`: Comma-separated list of sensitive data types
+  to include when scanning. Use `all` to include all built-in patterns (default: none).
 - `--exclude-sensitive-data-types`: Comma-separated list of sensitive data types
   to skip when scanning (default: none).
 - `--custom-patterns`: Custom sensitive data patterns as name:regex pairs

--- a/docs/README.md
+++ b/docs/README.md
@@ -14,8 +14,11 @@ This directory contains extended documentation for Safnari.
 
 Safnari collects file metadata and system information from user specified paths. It can hash files,
 search for sensitive strings such as emails, credit cards, AWS keys, JWT tokens, street addresses,
-and custom regex patterns, and report system details such as running processes. The goal of this
-documentation is to provide deeper explanations and examples than the top level README.
+IBANs, UK National Insurance numbers, EU VAT IDs, India Aadhaar numbers,
+China resident IDs, and custom regex patterns. Sensitive data checks can be
+enabled or disabled individually. Safnari also reports system details such as
+running processes. The goal of this documentation is to provide deeper
+explanations and examples than the top level README.
 
 ## Building
 
@@ -89,7 +92,9 @@ Safnari accepts the following flags. Each description lists the default value in
 - `--extended-process-info`: Gather extended process information (requires
   elevated privileges) (default: `false`).
 - `--sensitive-data-types`: Comma-separated list of sensitive data types to scan
-  for (default: none).
+  for. Use `all` to include all built-in patterns (default: none).
+- `--exclude-sensitive-data-types`: Comma-separated list of sensitive data types
+  to skip when scanning (default: none).
 - `--custom-patterns`: Custom sensitive data patterns as name:regex pairs
   (default: none).
 - `--fuzzy-hash`: Enable fuzzy hashing (ssdeep) (default: `false`).

--- a/src/config/config.go
+++ b/src/config/config.go
@@ -32,7 +32,7 @@ type Config struct {
 	MaxIOPerSecond      int               `json:"max_io_per_second"`
 	ConfigFile          string            `json:"config_file"`
 	ExtendedProcessInfo bool              `json:"extended_process_info"`
-	SensitiveDataTypes  []string          `json:"sensitive_data_types"`
+	IncludeDataTypes    []string          `json:"include_sensitive_data_types"`
 	ExcludeDataTypes    []string          `json:"exclude_sensitive_data_types"`
 	CustomPatterns      map[string]string `json:"custom_patterns"`
 	FuzzyHash           bool              `json:"fuzzy_hash"`
@@ -46,25 +46,25 @@ func LoadConfig() (*Config, error) {
 	now := time.Now().UTC()
 	timestamp := now.Format("20060102-150405")
 	cfg := &Config{
-		StartPaths:         []string{"."},
-		ScanFiles:          true,
-		ScanProcesses:      true,
-		OutputFormat:       "json",
-		OutputFileName:     fmt.Sprintf("safnari-%s-%d.json", timestamp, now.Unix()),
-		ConcurrencyLevel:   runtime.NumCPU(),
-		NiceLevel:          "medium",
-		HashAlgorithms:     []string{"md5", "sha1", "sha256"},
-		SearchTerms:        []string{},
-		MaxFileSize:        10485760,
-		MaxOutputFileSize:  104857600,
-		LogLevel:           "info",
-		MaxIOPerSecond:     1000,
-		SensitiveDataTypes: []string{},
-		ExcludeDataTypes:   []string{},
-		CustomPatterns:     map[string]string{},
-		DeltaScan:          false,
-		LastScanFile:       ".safnari_last_scan",
-		SkipCount:          false,
+		StartPaths:        []string{"."},
+		ScanFiles:         true,
+		ScanProcesses:     true,
+		OutputFormat:      "json",
+		OutputFileName:    fmt.Sprintf("safnari-%s-%d.json", timestamp, now.Unix()),
+		ConcurrencyLevel:  runtime.NumCPU(),
+		NiceLevel:         "medium",
+		HashAlgorithms:    []string{"md5", "sha1", "sha256"},
+		SearchTerms:       []string{},
+		MaxFileSize:       10485760,
+		MaxOutputFileSize: 104857600,
+		LogLevel:          "info",
+		MaxIOPerSecond:    1000,
+		IncludeDataTypes:  []string{},
+		ExcludeDataTypes:  []string{},
+		CustomPatterns:    map[string]string{},
+		DeltaScan:         false,
+		LastScanFile:      ".safnari_last_scan",
+		SkipCount:         false,
 	}
 
 	startPath := flag.String("path", strings.Join(cfg.StartPaths, ","), fmt.Sprintf("Comma-separated list of start paths to scan (default: %s).", strings.Join(cfg.StartPaths, ",")))
@@ -86,7 +86,7 @@ func LoadConfig() (*Config, error) {
 	skipCount := flag.Bool("skip-count", cfg.SkipCount, "Skip initial file counting to start scanning immediately")
 	configFile := flag.String("config", "", "Path to JSON configuration file (default: none).")
 	extendedProcessInfo := flag.Bool("extended-process-info", cfg.ExtendedProcessInfo, fmt.Sprintf("Gather extended process information (requires elevated privileges) (default: %t).", cfg.ExtendedProcessInfo))
-	sensitiveDataTypes := flag.String("sensitive-data-types", "", "Comma-separated list of sensitive data types to scan for (default: none). Use 'all' to include all built-in types.")
+	includeDataTypes := flag.String("include-sensitive-data-types", "", "Comma-separated list of sensitive data types to include when scanning (default: none). Use 'all' to include all built-in types.")
 	excludeDataTypes := flag.String("exclude-sensitive-data-types", "", "Comma-separated list of sensitive data types to exclude when scanning.")
 	customPatterns := flag.String("custom-patterns", "", "Custom sensitive data patterns in the format name:regex,...")
 	fuzzyHash := flag.Bool("fuzzy-hash", cfg.FuzzyHash, fmt.Sprintf("Enable fuzzy hashing (ssdeep) (default: %t).", cfg.FuzzyHash))
@@ -146,8 +146,8 @@ func LoadConfig() (*Config, error) {
 			cfg.MaxIOPerSecond = *maxIO
 		case "extended-process-info":
 			cfg.ExtendedProcessInfo = *extendedProcessInfo
-		case "sensitive-data-types":
-			cfg.SensitiveDataTypes = parseCommaSeparated(*sensitiveDataTypes)
+		case "include-sensitive-data-types":
+			cfg.IncludeDataTypes = parseCommaSeparated(*includeDataTypes)
 		case "exclude-sensitive-data-types":
 			cfg.ExcludeDataTypes = parseCommaSeparated(*excludeDataTypes)
 		case "custom-patterns":

--- a/src/config/config.go
+++ b/src/config/config.go
@@ -33,6 +33,7 @@ type Config struct {
 	ConfigFile          string            `json:"config_file"`
 	ExtendedProcessInfo bool              `json:"extended_process_info"`
 	SensitiveDataTypes  []string          `json:"sensitive_data_types"`
+	ExcludeDataTypes    []string          `json:"exclude_sensitive_data_types"`
 	CustomPatterns      map[string]string `json:"custom_patterns"`
 	FuzzyHash           bool              `json:"fuzzy_hash"`
 	DeltaScan           bool              `json:"delta_scan"`
@@ -59,6 +60,7 @@ func LoadConfig() (*Config, error) {
 		LogLevel:           "info",
 		MaxIOPerSecond:     1000,
 		SensitiveDataTypes: []string{},
+		ExcludeDataTypes:   []string{},
 		CustomPatterns:     map[string]string{},
 		DeltaScan:          false,
 		LastScanFile:       ".safnari_last_scan",
@@ -84,7 +86,8 @@ func LoadConfig() (*Config, error) {
 	skipCount := flag.Bool("skip-count", cfg.SkipCount, "Skip initial file counting to start scanning immediately")
 	configFile := flag.String("config", "", "Path to JSON configuration file (default: none).")
 	extendedProcessInfo := flag.Bool("extended-process-info", cfg.ExtendedProcessInfo, fmt.Sprintf("Gather extended process information (requires elevated privileges) (default: %t).", cfg.ExtendedProcessInfo))
-	sensitiveDataTypes := flag.String("sensitive-data-types", "", "Comma-separated list of sensitive data types to scan for (default: none).")
+	sensitiveDataTypes := flag.String("sensitive-data-types", "", "Comma-separated list of sensitive data types to scan for (default: none). Use 'all' to include all built-in types.")
+	excludeDataTypes := flag.String("exclude-sensitive-data-types", "", "Comma-separated list of sensitive data types to exclude when scanning.")
 	customPatterns := flag.String("custom-patterns", "", "Custom sensitive data patterns in the format name:regex,...")
 	fuzzyHash := flag.Bool("fuzzy-hash", cfg.FuzzyHash, fmt.Sprintf("Enable fuzzy hashing (ssdeep) (default: %t).", cfg.FuzzyHash))
 	deltaScan := flag.Bool("delta-scan", cfg.DeltaScan, fmt.Sprintf("Only scan files modified since the last run (default: %t).", cfg.DeltaScan))
@@ -145,6 +148,8 @@ func LoadConfig() (*Config, error) {
 			cfg.ExtendedProcessInfo = *extendedProcessInfo
 		case "sensitive-data-types":
 			cfg.SensitiveDataTypes = parseCommaSeparated(*sensitiveDataTypes)
+		case "exclude-sensitive-data-types":
+			cfg.ExcludeDataTypes = parseCommaSeparated(*excludeDataTypes)
 		case "custom-patterns":
 			cfg.CustomPatterns = parseCustomPatterns(*customPatterns)
 		case "fuzzy-hash":

--- a/src/config/config_test.go
+++ b/src/config/config_test.go
@@ -17,6 +17,16 @@ func TestParseCommaSeparated(t *testing.T) {
 	}
 }
 
+func TestParseCustomPatterns(t *testing.T) {
+	res := parseCustomPatterns("a:1+,b:2?")
+	if res["a"] != "1+" || res["b"] != "2?" {
+		t.Fatalf("unexpected result: %v", res)
+	}
+	if res := parseCustomPatterns(""); len(res) != 0 {
+		t.Fatalf("expected empty map")
+	}
+}
+
 func TestLoadFromFile(t *testing.T) {
 	tmp, err := os.CreateTemp("", "cfg*.json")
 	if err != nil {

--- a/src/config/config_test.go
+++ b/src/config/config_test.go
@@ -107,3 +107,20 @@ func TestFuzzyHashFlagAddsAlgorithm(t *testing.T) {
 		t.Fatal("ssdeep algorithm not added")
 	}
 }
+
+func TestExcludeSensitiveFlag(t *testing.T) {
+	oldArgs := os.Args
+	defer func() { os.Args = oldArgs }()
+	oldFlag := flag.CommandLine
+	flag.CommandLine = flag.NewFlagSet(os.Args[0], flag.ExitOnError)
+	defer func() { flag.CommandLine = oldFlag }()
+
+	os.Args = []string{"cmd", "--sensitive-data-types", "email,credit_card", "--exclude-sensitive-data-types", "email"}
+	cfg, err := LoadConfig()
+	if err != nil {
+		t.Fatalf("load: %v", err)
+	}
+	if len(cfg.SensitiveDataTypes) != 2 || len(cfg.ExcludeDataTypes) != 1 || cfg.ExcludeDataTypes[0] != "email" {
+		t.Fatalf("unexpected cfg: %+v", cfg)
+	}
+}

--- a/src/config/config_test.go
+++ b/src/config/config_test.go
@@ -108,19 +108,19 @@ func TestFuzzyHashFlagAddsAlgorithm(t *testing.T) {
 	}
 }
 
-func TestExcludeSensitiveFlag(t *testing.T) {
+func TestIncludeSensitiveFlag(t *testing.T) {
 	oldArgs := os.Args
 	defer func() { os.Args = oldArgs }()
 	oldFlag := flag.CommandLine
 	flag.CommandLine = flag.NewFlagSet(os.Args[0], flag.ExitOnError)
 	defer func() { flag.CommandLine = oldFlag }()
 
-	os.Args = []string{"cmd", "--sensitive-data-types", "email,credit_card", "--exclude-sensitive-data-types", "email"}
+	os.Args = []string{"cmd", "--include-sensitive-data-types", "email,credit_card", "--exclude-sensitive-data-types", "email"}
 	cfg, err := LoadConfig()
 	if err != nil {
 		t.Fatalf("load: %v", err)
 	}
-	if len(cfg.SensitiveDataTypes) != 2 || len(cfg.ExcludeDataTypes) != 1 || cfg.ExcludeDataTypes[0] != "email" {
+	if len(cfg.IncludeDataTypes) != 2 || len(cfg.ExcludeDataTypes) != 1 || cfg.ExcludeDataTypes[0] != "email" {
 		t.Fatalf("unexpected cfg: %+v", cfg)
 	}
 }

--- a/src/config/config_test.go
+++ b/src/config/config_test.go
@@ -18,9 +18,13 @@ func TestParseCommaSeparated(t *testing.T) {
 }
 
 func TestParseCustomPatterns(t *testing.T) {
-	res := parseCustomPatterns("a:1+,b:2?")
+	res := parseCustomPatterns(`{"a":"1+","b":"2?"}`)
 	if res["a"] != "1+" || res["b"] != "2?" {
 		t.Fatalf("unexpected result: %v", res)
+	}
+	res = parseCustomPatterns(`{"ipv6":"[a-fA-F0-9:]{2,}"}`)
+	if res["ipv6"] != "[a-fA-F0-9:]{2,}" {
+		t.Fatalf("failed to parse complex regex: %v", res["ipv6"])
 	}
 	if res := parseCustomPatterns(""); len(res) != 0 {
 		t.Fatalf("expected empty map")

--- a/src/scanner/scanner.go
+++ b/src/scanner/scanner.go
@@ -87,7 +87,7 @@ func ScanFiles(ctx context.Context, cfg *config.Config, metrics *output.Metrics,
 	adjustConcurrency(cfg)
 
 	// Prepare sensitive data patterns
-	sensitivePatterns := GetPatterns(cfg.SensitiveDataTypes, cfg.CustomPatterns)
+	sensitivePatterns := GetPatterns(cfg.SensitiveDataTypes, cfg.CustomPatterns, cfg.ExcludeDataTypes)
 
 	// Implement I/O rate limiter
 	ioLimiter := rate.NewLimiter(rate.Limit(cfg.MaxIOPerSecond), cfg.MaxIOPerSecond)

--- a/src/scanner/scanner.go
+++ b/src/scanner/scanner.go
@@ -87,7 +87,7 @@ func ScanFiles(ctx context.Context, cfg *config.Config, metrics *output.Metrics,
 	adjustConcurrency(cfg)
 
 	// Prepare sensitive data patterns
-	sensitivePatterns := GetPatterns(cfg.SensitiveDataTypes)
+	sensitivePatterns := GetPatterns(cfg.SensitiveDataTypes, cfg.CustomPatterns)
 
 	// Implement I/O rate limiter
 	ioLimiter := rate.NewLimiter(rate.Limit(cfg.MaxIOPerSecond), cfg.MaxIOPerSecond)

--- a/src/scanner/scanner.go
+++ b/src/scanner/scanner.go
@@ -87,7 +87,7 @@ func ScanFiles(ctx context.Context, cfg *config.Config, metrics *output.Metrics,
 	adjustConcurrency(cfg)
 
 	// Prepare sensitive data patterns
-	sensitivePatterns := GetPatterns(cfg.SensitiveDataTypes, cfg.CustomPatterns, cfg.ExcludeDataTypes)
+	sensitivePatterns := GetPatterns(cfg.IncludeDataTypes, cfg.CustomPatterns, cfg.ExcludeDataTypes)
 
 	// Implement I/O rate limiter
 	ioLimiter := rate.NewLimiter(rate.Limit(cfg.MaxIOPerSecond), cfg.MaxIOPerSecond)

--- a/src/scanner/scanner_test.go
+++ b/src/scanner/scanner_test.go
@@ -123,6 +123,16 @@ func TestExcludeSensitiveDataTypes(t *testing.T) {
 	}
 }
 
+func TestExcludeOnlyDefaultsToAll(t *testing.T) {
+	patterns := GetPatterns(nil, nil, []string{"email"})
+	if _, ok := patterns["email"]; ok {
+		t.Fatal("email should have been excluded")
+	}
+	if _, ok := patterns["credit_card"]; !ok {
+		t.Fatal("expected credit card pattern when only exclude specified")
+	}
+}
+
 func TestGetFileAttributes(t *testing.T) {
 	tmp, _ := os.CreateTemp("", "attr")
 	tmp.Close()

--- a/src/scanner/scanner_test.go
+++ b/src/scanner/scanner_test.go
@@ -62,10 +62,36 @@ func TestScanForSensitiveData(t *testing.T) {
 	tmp.WriteString(content)
 	tmp.Close()
 	defer os.Remove(tmp.Name())
-	patterns := GetPatterns([]string{"email"})
+	patterns := GetPatterns([]string{"email"}, nil)
 	matches := scanForSensitiveData(tmp.Name(), patterns)
 	if len(matches["email"]) == 0 {
 		t.Fatal("expected email match")
+	}
+}
+
+func TestScanForSensitiveDataCreditCard(t *testing.T) {
+	tmp, _ := os.CreateTemp("", "cc*.txt")
+	content := "valid 4111-1111-1111-1111 invalid 1234-5678-9012-3456"
+	tmp.WriteString(content)
+	tmp.Close()
+	defer os.Remove(tmp.Name())
+	patterns := GetPatterns([]string{"credit_card"}, nil)
+	matches := scanForSensitiveData(tmp.Name(), patterns)
+	if len(matches["credit_card"]) != 1 || matches["credit_card"][0] != "4111-1111-1111-1111" {
+		t.Fatalf("expected valid credit card match, got %v", matches["credit_card"])
+	}
+}
+
+func TestCustomSensitivePattern(t *testing.T) {
+	tmp, _ := os.CreateTemp("", "custom*.txt")
+	tmp.WriteString("token abc123")
+	tmp.Close()
+	defer os.Remove(tmp.Name())
+	custom := map[string]string{"token": "abc\\d+"}
+	patterns := GetPatterns([]string{"token"}, custom)
+	matches := scanForSensitiveData(tmp.Name(), patterns)
+	if len(matches["token"]) == 0 {
+		t.Fatal("expected custom pattern match")
 	}
 }
 
@@ -88,7 +114,7 @@ func TestCollectFileData(t *testing.T) {
 	defer os.Remove(tmp.Name())
 	fi, _ := os.Stat(tmp.Name())
 	cfg := &config.Config{HashAlgorithms: []string{"md5"}, MaxFileSize: 1024}
-	patterns := GetPatterns([]string{"email"})
+	patterns := GetPatterns([]string{"email"}, nil)
 	data, err := collectFileData(tmp.Name(), fi, cfg, patterns)
 	if err != nil {
 		t.Fatalf("collect: %v", err)
@@ -118,7 +144,7 @@ func TestProcessFile(t *testing.T) {
 	}
 	defer w.Close()
 
-	patterns := GetPatterns([]string{"email"})
+	patterns := GetPatterns([]string{"email"}, nil)
 	ctx := context.Background()
 	ProcessFile(ctx, tmp.Name(), cfg, w, patterns)
 }

--- a/src/scanner/sensitive_patterns.go
+++ b/src/scanner/sensitive_patterns.go
@@ -12,20 +12,45 @@ var sensitivePatterns = map[string]*regexp.Regexp{
 	"aws_access_key": regexp.MustCompile(`AKIA[0-9A-Z]{16}`),
 	"jwt_token":      regexp.MustCompile(`eyJ[\w-]+?\.[\w-]+?\.[\w-]+`),
 	"street_address": regexp.MustCompile(`\b\d{1,5}\s+[A-Za-z0-9]+(?:\s+[A-Za-z0-9]+)*\s+(?:Street|St|Avenue|Ave|Boulevard|Blvd|Road|Rd|Lane|Ln|Drive|Dr)\b`),
+	"iban":           regexp.MustCompile(`\b[A-Z]{2}[0-9]{2}[A-Z0-9]{11,30}\b`),
+	"uk_nin":         regexp.MustCompile(`\b[A-CEGHJ-PR-TW-Z]{2}\d{6}[A-D]\b`),
+	"eu_vat":         regexp.MustCompile(`\b[A-Z]{2}[0-9A-Z]{8,12}\b`),
+	"india_aadhaar":  regexp.MustCompile(`\b\d{4}\s?\d{4}\s?\d{4}\b`),
+	"china_id":       regexp.MustCompile(`\b\d{17}[0-9Xx]\b`),
 }
 
-func GetPatterns(types []string, custom map[string]string) map[string]*regexp.Regexp {
+func GetPatterns(types []string, custom map[string]string, exclude []string) map[string]*regexp.Regexp {
 	patterns := make(map[string]*regexp.Regexp)
-	for _, t := range types {
-		if pattern, exists := sensitivePatterns[t]; exists {
-			patterns[t] = pattern
-		} else if custom != nil {
-			if regex, ok := custom[t]; ok {
-				if compiled, err := regexp.Compile(regex); err == nil {
-					patterns[t] = compiled
-				}
+
+	available := make(map[string]*regexp.Regexp)
+	for k, v := range sensitivePatterns {
+		available[k] = v
+	}
+	if custom != nil {
+		for name, regex := range custom {
+			if compiled, err := regexp.Compile(regex); err == nil {
+				available[name] = compiled
 			}
 		}
+	}
+
+	selected := make(map[string]bool)
+	for _, t := range types {
+		if t == "all" {
+			for name := range available {
+				selected[name] = true
+			}
+		} else if _, exists := available[t]; exists {
+			selected[t] = true
+		}
+	}
+
+	for _, ex := range exclude {
+		delete(selected, ex)
+	}
+
+	for name := range selected {
+		patterns[name] = available[name]
 	}
 	return patterns
 }

--- a/src/scanner/sensitive_patterns.go
+++ b/src/scanner/sensitive_patterns.go
@@ -35,13 +35,21 @@ func GetPatterns(types []string, custom map[string]string, exclude []string) map
 	}
 
 	selected := make(map[string]bool)
-	for _, t := range types {
-		if t == "all" {
+	if len(types) == 0 {
+		if len(exclude) > 0 {
 			for name := range available {
 				selected[name] = true
 			}
-		} else if _, exists := available[t]; exists {
-			selected[t] = true
+		}
+	} else {
+		for _, t := range types {
+			if t == "all" {
+				for name := range available {
+					selected[name] = true
+				}
+			} else if _, exists := available[t]; exists {
+				selected[t] = true
+			}
 		}
 	}
 

--- a/src/scanner/sensitive_patterns.go
+++ b/src/scanner/sensitive_patterns.go
@@ -3,21 +3,29 @@ package scanner
 import "regexp"
 
 var sensitivePatterns = map[string]*regexp.Regexp{
-    "email":        regexp.MustCompile(`[a-zA-Z0-9._%+\-]+@[a-zA-Z0-9.\-]+\.[a-zA-Z]{2,}`),
-    "credit_card":  regexp.MustCompile(`\b(?:\d[ -]*?){13,16}\b`),
-    "ssn":          regexp.MustCompile(`\b\d{3}-\d{2}-\d{4}\b`),
-    "ip_address":   regexp.MustCompile(`\b(?:\d{1,3}\.){3}\d{1,3}\b`),
-    "api_key":      regexp.MustCompile(`(?i)(api_key|api-secret|access-token)[\s:=]+"?[\w\-]+"?`),
-    "phone_number": regexp.MustCompile(`\b\(?\d{3}\)?[-.\s]?\d{3}[-.\s]?\d{4}\b`),
-    // Add more patterns as needed
+	"email":          regexp.MustCompile(`[a-zA-Z0-9._%+\-]+@[a-zA-Z0-9.\-]+\.[a-zA-Z]{2,}`),
+	"credit_card":    regexp.MustCompile(`\b(?:\d[ -]*?){13,16}\b`),
+	"ssn":            regexp.MustCompile(`\b\d{3}-\d{2}-\d{4}\b`),
+	"ip_address":     regexp.MustCompile(`\b(?:\d{1,3}\.){3}\d{1,3}\b`),
+	"api_key":        regexp.MustCompile(`(?i)(api_key|api-secret|access-token)[\s:=]+"?[\w\-]+"?`),
+	"phone_number":   regexp.MustCompile(`\b\(?\d{3}\)?[-.\s]?\d{3}[-.\s]?\d{4}\b`),
+	"aws_access_key": regexp.MustCompile(`AKIA[0-9A-Z]{16}`),
+	"jwt_token":      regexp.MustCompile(`eyJ[\w-]+?\.[\w-]+?\.[\w-]+`),
+	"street_address": regexp.MustCompile(`\b\d{1,5}\s+[A-Za-z0-9]+(?:\s+[A-Za-z0-9]+)*\s+(?:Street|St|Avenue|Ave|Boulevard|Blvd|Road|Rd|Lane|Ln|Drive|Dr)\b`),
 }
 
-func GetPatterns(types []string) map[string]*regexp.Regexp {
-    patterns := make(map[string]*regexp.Regexp)
-    for _, t := range types {
-        if pattern, exists := sensitivePatterns[t]; exists {
-            patterns[t] = pattern
-        }
-    }
-    return patterns
+func GetPatterns(types []string, custom map[string]string) map[string]*regexp.Regexp {
+	patterns := make(map[string]*regexp.Regexp)
+	for _, t := range types {
+		if pattern, exists := sensitivePatterns[t]; exists {
+			patterns[t] = pattern
+		} else if custom != nil {
+			if regex, ok := custom[t]; ok {
+				if compiled, err := regexp.Compile(regex); err == nil {
+					patterns[t] = compiled
+				}
+			}
+		}
+	}
+	return patterns
 }


### PR DESCRIPTION
## Summary
- support custom regexes for sensitive data via `--custom-patterns`
- detect AWS access keys, JWT tokens, and street addresses
- reduce credit card false positives using Luhn validation

## Testing
- `make lint`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_68bb03b4fb408333ba76aaf98bd62197