### PR TITLE
Auto-release on successful main builds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,12 +48,21 @@ jobs:
 
   release:
     needs: build
-    if: startsWith(github.ref, 'refs/tags/')
+    if: github.event_name == 'push'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/download-artifact@v4
         with:
           path: bin
-      - uses: softprops/action-gh-release@v1
+      - name: Release on tag
+        if: startsWith(github.ref, 'refs/tags/')
+        uses: softprops/action-gh-release@v1
         with:
           files: bin/**
+      - name: Release on main
+        if: github.ref == 'refs/heads/main'
+        uses: softprops/action-gh-release@v1
+        with:
+          files: bin/**
+          tag_name: main-${{ github.sha }}
+          name: main-${{ github.sha }}


### PR DESCRIPTION
## Summary
- add CI logic to publish releases for successful main branch builds
- retain tag-based release and tag main commits as `main-<sha>`

## Testing
- `make lint`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_68bb16ab6cd8833392bf847944b7af73