### PR TITLE
feat: date-based release naming

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,6 +54,17 @@ jobs:
       - uses: actions/download-artifact@v4
         with:
           path: bin
+      - name: Compute release tag
+        id: release_tag
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
+        run: |
+          date=$(date -u +%Y%m%d)
+          count=$(gh release list --limit 100 --json tagName \
+            | jq --arg date "$date" '[.[] | select(.tagName | startswith("safnari-" + $date))] | length')
+          letter=$(printf '%b' "$(printf '\\%03o' $((97 + count)))")
+          echo "tag=safnari-${date}${letter}" >> "$GITHUB_OUTPUT"
       - name: Release on tag
         if: startsWith(github.ref, 'refs/tags/')
         uses: softprops/action-gh-release@v1
@@ -64,5 +75,5 @@ jobs:
         uses: softprops/action-gh-release@v1
         with:
           files: bin/**
-          tag_name: main-${{ github.sha }}
-          name: main-${{ github.sha }}
+          tag_name: ${{ steps.release_tag.outputs.tag }}
+          name: ${{ steps.release_tag.outputs.tag }}

--- a/README.md
+++ b/README.md
@@ -65,7 +65,9 @@ Trace-enabled builds record code-level tasks and regions to `trace.out`. Use
 ### Download Pre-Compiled Binary
 
 Check the [releases page](https://github.com/ProvisioInsights/Safnari/releases) for
-binaries for your operating system.
+binaries for your operating system. Releases use the `safnari-<date><letter>` naming
+scheme, where `date` is in `YYYYMMDD` format and `letter` increments if multiple releases
+occur on the same day.
 
 ## Usage
 


### PR DESCRIPTION
## Summary
- compute release tags from date with incrementing letter for main releases
- document release naming convention for binaries

## Testing
- `make lint`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_68bb1a386d608333b05a763358bb7a36