### PR TITLE
Add system info toggle and respect process scan flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,8 @@ configuration flags for filtering, hashing, and output control.
 - Calculate file hashes (MD5, SHA1, SHA256)
 - Extract metadata from images (EXIF), PDFs, and DOCX documents
  - Detect sensitive data patterns such as emails, credit cards (with Luhn validation), AWS keys, JWT tokens, street addresses, IBANs, UK National Insurance numbers, EU VAT IDs, India Aadhaar numbers, China resident IDs, and user-defined regexes via the `--custom-patterns` JSON flag. Users can scan only selected types with `--include-sensitive-data-types` or skip some with `--exclude-sensitive-data-types`.
+- Toggle system information gathering, file metadata scanning, sensitive data detection,
+  and process enumeration independently via CLI flags
 - Output results with metrics in JSON format
 
 ## Installation
@@ -89,7 +91,9 @@ Running Safnari without any flags applies these defaults:
 - `--path`: `.`
 - `--all-drives`: `false`
 - `--scan-files`: `true`
+- `--scan-sensitive`: `true`
 - `--scan-processes`: `true`
+- `--collect-system-info`: `true`
 - `--format`: `json`
 - `--output`: `safnari-<timestamp>-<unix>.json`
 - `--concurrency`: number of logical CPUs

--- a/docs/README.md
+++ b/docs/README.md
@@ -16,10 +16,10 @@ Safnari collects file metadata and system information from user specified paths.
 search for sensitive strings such as emails, credit cards, AWS keys, JWT tokens, street addresses,
 IBANs, UK National Insurance numbers, EU VAT IDs, India Aadhaar numbers, China resident IDs, and
 custom regex patterns supplied via the `--custom-patterns` JSON flag. Scan only selected types with
-`--include-sensitive-data-types` or skip some with `--exclude-sensitive-data-types`.
-Safnari also reports system details such as
-running processes. The goal of this documentation is to provide deeper
-explanations and examples than the top level README.
+`--include-sensitive-data-types` or skip some with `--exclude-sensitive-data-types`. Safnari also
+reports system details such as running processes. File metadata collection, system information
+gathering, process enumeration, and sensitive data scanning can be enabled independently. The goal
+of this documentation is to provide deeper explanations and examples than the top level README.
 
 ## Building
 
@@ -75,7 +75,9 @@ Safnari accepts the following flags. Each description lists the default value in
 - `--path`: Comma-separated list of start paths to scan (default: `.`).
 - `--all-drives`: Scan all local drives (Windows only) (default: `false`).
 - `--scan-files`: Enable file scanning (default: `true`).
+- `--scan-sensitive`: Enable sensitive data scanning (default: `true`).
 - `--scan-processes`: Enable process scanning (default: `true`).
+- `--collect-system-info`: Collect system information (default: `true`).
 - `--format`: Output format: json or csv (default: `json`).
 - `--output`: Output file name (default: `safnari-<timestamp>-<unix>.json`).
 - `--concurrency`: Concurrency level (default: number of logical CPUs).

--- a/src/cmd/main.go
+++ b/src/cmd/main.go
@@ -52,10 +52,13 @@ func main() {
 		StartTime: startTime.Format(time.RFC3339),
 	}
 
-	// Gather system information
-	sysInfo, err := systeminfo.GetSystemInfo(cfg)
-	if err != nil {
-		logger.Errorf("Failed to gather system information: %v", err)
+	// Gather system information if requested
+	var sysInfo *systeminfo.SystemInfo
+	if cfg.CollectSystemInfo || cfg.ScanProcesses {
+		sysInfo, err = systeminfo.GetSystemInfo(cfg)
+		if err != nil {
+			logger.Errorf("Failed to gather system information: %v", err)
+		}
 	}
 
 	// Prepare output
@@ -74,9 +77,11 @@ func main() {
 	go handleSignals(cancel, &metrics, writer)
 
 	// Start scanning
-	err = scanner.ScanFiles(ctx, cfg, &metrics, writer)
-	if err != nil {
-		logger.Fatalf("Scanning failed: %v", err)
+	if cfg.ScanFiles || cfg.ScanSensitive {
+		err = scanner.ScanFiles(ctx, cfg, &metrics, writer)
+		if err != nil {
+			logger.Fatalf("Scanning failed: %v", err)
+		}
 	}
 
 	// Record end time

--- a/src/output/output.go
+++ b/src/output/output.go
@@ -36,6 +36,10 @@ func New(cfg *config.Config, sysInfo *systeminfo.SystemInfo, m *Metrics) (*Write
 	ext := filepath.Ext(cfg.OutputFileName)
 	base := strings.TrimSuffix(cfg.OutputFileName, ext)
 
+	if sysInfo == nil {
+		sysInfo = &systeminfo.SystemInfo{}
+	}
+
 	w := &Writer{
 		first:   true,
 		metrics: m,

--- a/src/scanner/scanner_test.go
+++ b/src/scanner/scanner_test.go
@@ -151,7 +151,7 @@ func TestCollectFileData(t *testing.T) {
 	tmp.Close()
 	defer os.Remove(tmp.Name())
 	fi, _ := os.Stat(tmp.Name())
-	cfg := &config.Config{HashAlgorithms: []string{"md5"}, MaxFileSize: 1024}
+	cfg := &config.Config{HashAlgorithms: []string{"md5"}, MaxFileSize: 1024, ScanFiles: true, ScanSensitive: true}
 	patterns := GetPatterns([]string{"email"}, nil, nil)
 	data, err := collectFileData(tmp.Name(), fi, cfg, patterns)
 	if err != nil {
@@ -173,7 +173,7 @@ func TestProcessFile(t *testing.T) {
 
 	outFile, _ := os.CreateTemp("", "out*.json")
 	defer os.Remove(outFile.Name())
-	cfg := &config.Config{HashAlgorithms: []string{"md5"}, MaxFileSize: 1024, OutputFileName: outFile.Name()}
+	cfg := &config.Config{HashAlgorithms: []string{"md5"}, MaxFileSize: 1024, ScanFiles: true, ScanSensitive: true, OutputFileName: outFile.Name()}
 	sys := &systeminfo.SystemInfo{RunningProcesses: []systeminfo.ProcessInfo{}}
 	metrics := &output.Metrics{}
 	w, err := output.New(cfg, sys, metrics)

--- a/src/systeminfo/systeminfo.go
+++ b/src/systeminfo/systeminfo.go
@@ -34,36 +34,40 @@ type ProcessInfo struct {
 func GetSystemInfo(cfg *config.Config) (*SystemInfo, error) {
 	sysInfo := &SystemInfo{}
 
-	if err := gatherOSVersion(sysInfo); err != nil {
-		logger.Warnf("Failed to gather OS version: %v", err)
+	if cfg.CollectSystemInfo {
+		if err := gatherOSVersion(sysInfo); err != nil {
+			logger.Warnf("Failed to gather OS version: %v", err)
+		}
+
+		if err := gatherInstalledPatches(sysInfo); err != nil {
+			logger.Warnf("Failed to gather installed patches: %v", err)
+		}
+
+		if err := gatherStartupPrograms(sysInfo); err != nil {
+			logger.Warnf("Failed to gather startup programs: %v", err)
+		}
+
+		if err := gatherInstalledApps(sysInfo); err != nil {
+			logger.Warnf("Failed to gather installed applications: %v", err)
+		}
+
+		if err := gatherNetworkInterfaces(sysInfo); err != nil {
+			logger.Warnf("Failed to gather network interfaces: %v", err)
+		}
+
+		if err := gatherOpenConnections(sysInfo); err != nil {
+			logger.Warnf("Failed to gather network connections: %v", err)
+		}
+
+		if err := gatherRunningServices(sysInfo); err != nil {
+			logger.Warnf("Failed to gather running services: %v", err)
+		}
 	}
 
-	if err := gatherInstalledPatches(sysInfo); err != nil {
-		logger.Warnf("Failed to gather installed patches: %v", err)
-	}
-
-	if err := gatherRunningProcesses(sysInfo, cfg.ExtendedProcessInfo); err != nil {
-		logger.Warnf("Failed to gather running processes: %v", err)
-	}
-
-	if err := gatherStartupPrograms(sysInfo); err != nil {
-		logger.Warnf("Failed to gather startup programs: %v", err)
-	}
-
-	if err := gatherInstalledApps(sysInfo); err != nil {
-		logger.Warnf("Failed to gather installed applications: %v", err)
-	}
-
-	if err := gatherNetworkInterfaces(sysInfo); err != nil {
-		logger.Warnf("Failed to gather network interfaces: %v", err)
-	}
-
-	if err := gatherOpenConnections(sysInfo); err != nil {
-		logger.Warnf("Failed to gather network connections: %v", err)
-	}
-
-	if err := gatherRunningServices(sysInfo); err != nil {
-		logger.Warnf("Failed to gather running services: %v", err)
+	if cfg.ScanProcesses {
+		if err := gatherRunningProcesses(sysInfo, cfg.ExtendedProcessInfo); err != nil {
+			logger.Warnf("Failed to gather running processes: %v", err)
+		}
 	}
 
 	return sysInfo, nil

--- a/src/systeminfo/systeminfo_test.go
+++ b/src/systeminfo/systeminfo_test.go
@@ -22,6 +22,26 @@ func TestGetSystemInfo(t *testing.T) {
 	}
 }
 
+func TestGetSystemInfoProcessFlag(t *testing.T) {
+	cfg := &config.Config{ScanProcesses: true}
+	info, err := GetSystemInfo(cfg)
+	if err != nil {
+		t.Fatalf("get: %v", err)
+	}
+	if len(info.RunningProcesses) == 0 {
+		t.Fatal("expected running processes when enabled")
+	}
+
+	cfg = &config.Config{CollectSystemInfo: true, ScanProcesses: false}
+	info, err = GetSystemInfo(cfg)
+	if err != nil {
+		t.Fatalf("get: %v", err)
+	}
+	if len(info.RunningProcesses) != 0 {
+		t.Fatal("expected no running processes when disabled")
+	}
+}
+
 func TestGatherRunningProcesses(t *testing.T) {
 	sys := &SystemInfo{}
 	if err := gatherRunningProcesses(sys, false); err != nil {

--- a/src/utils/path.go
+++ b/src/utils/path.go
@@ -1,0 +1,33 @@
+package utils
+
+import (
+	"path/filepath"
+	"strings"
+)
+
+// IsPathWithin returns true if the given path is within any of the roots.
+func IsPathWithin(path string, roots []string) bool {
+	resolved, err := filepath.EvalSymlinks(path)
+	if err != nil {
+		resolved = path
+	}
+	absPath, err := filepath.Abs(resolved)
+	if err != nil {
+		return false
+	}
+	for _, root := range roots {
+		rResolved, err := filepath.EvalSymlinks(root)
+		if err != nil {
+			rResolved = root
+		}
+		absRoot, err := filepath.Abs(rResolved)
+		if err != nil {
+			continue
+		}
+		rel, err := filepath.Rel(absRoot, absPath)
+		if err == nil && rel != ".." && !strings.HasPrefix(rel, ".."+string(filepath.Separator)) {
+			return true
+		}
+	}
+	return false
+}


### PR DESCRIPTION
## Summary
- allow system information gathering to be turned off and validate that at least one scan type is enabled
- only collect running processes when --scan-processes is set and skip other system details unless requested
- handle absent system info in output writer and document the new --collect-system-info flag

## Testing
- `make lint`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_68bb27197054833390f9a53104d03f8d