### PR TITLE
fix scanner security controls

### DIFF
--- a/src/internal/securefile/securefile_unix.go
+++ b/src/internal/securefile/securefile_unix.go
@@ -21,10 +21,21 @@ func OpenPrivateNoSymlink(path string) (*os.File, error) {
 	}
 	defer cleanup()
 
-	fd, err := unix.Openat(dirfd, base, unix.O_WRONLY|unix.O_CREAT|unix.O_TRUNC|unix.O_CLOEXEC|unix.O_NOFOLLOW, 0600)
+	fd, err := unix.Openat(dirfd, base, unix.O_WRONLY|unix.O_CREAT|unix.O_EXCL|unix.O_CLOEXEC|unix.O_NOFOLLOW, 0600)
 	if err != nil {
-		return nil, err
+		if err != unix.EEXIST {
+			return nil, err
+		}
+		fd, err = unix.Openat(dirfd, base, unix.O_WRONLY|unix.O_CLOEXEC|unix.O_NOFOLLOW, 0)
+		if err != nil {
+			return nil, err
+		}
+		return privateWritableFile(fd, path, true)
 	}
+	return privateWritableFile(fd, path, false)
+}
+
+func privateWritableFile(fd int, path string, truncate bool) (*os.File, error) {
 	if err := ensureRegular(fd, path); err != nil {
 		_ = unix.Close(fd)
 		return nil, err
@@ -32,6 +43,16 @@ func OpenPrivateNoSymlink(path string) (*os.File, error) {
 	if err := unix.Fchmod(fd, 0600); err != nil {
 		_ = unix.Close(fd)
 		return nil, err
+	}
+	if truncate {
+		if err := unix.Ftruncate(fd, 0); err != nil {
+			_ = unix.Close(fd)
+			return nil, err
+		}
+		if _, err := unix.Seek(fd, 0, io.SeekStart); err != nil {
+			_ = unix.Close(fd)
+			return nil, err
+		}
 	}
 	return os.NewFile(uintptr(fd), path), nil
 }

--- a/src/internal/securefile/securefile_unix.go
+++ b/src/internal/securefile/securefile_unix.go
@@ -29,6 +29,10 @@ func OpenPrivateNoSymlink(path string) (*os.File, error) {
 		_ = unix.Close(fd)
 		return nil, err
 	}
+	if err := unix.Fchmod(fd, 0600); err != nil {
+		_ = unix.Close(fd)
+		return nil, err
+	}
 	return os.NewFile(uintptr(fd), path), nil
 }
 

--- a/src/internal/securefile/securefile_unix_test.go
+++ b/src/internal/securefile/securefile_unix_test.go
@@ -26,6 +26,32 @@ func TestOpenPrivateNoSymlinkRejectsSymlinkParent(t *testing.T) {
 	}
 }
 
+func TestOpenPrivateNoSymlinkTightensAndTruncatesExistingFile(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "out.ndjson")
+	if err := os.WriteFile(path, []byte("stale"), 0644); err != nil {
+		t.Fatalf("write existing file: %v", err)
+	}
+
+	f, err := OpenPrivateNoSymlink(path)
+	if err != nil {
+		t.Fatalf("open private file: %v", err)
+	}
+	if err := f.Close(); err != nil {
+		t.Fatalf("close private file: %v", err)
+	}
+
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatalf("stat private file: %v", err)
+	}
+	if info.Size() != 0 {
+		t.Fatalf("expected existing file to be truncated, got size %d", info.Size())
+	}
+	if got := info.Mode().Perm(); got != 0600 {
+		t.Fatalf("expected mode 0600, got %04o", got)
+	}
+}
+
 func TestReadNoSymlinkRejectsSymlinkParent(t *testing.T) {
 	root := t.TempDir()
 	outside := t.TempDir()

--- a/src/output/output_test.go
+++ b/src/output/output_test.go
@@ -52,6 +52,33 @@ func TestOutputRejectsSymlinkTarget(t *testing.T) {
 	}
 }
 
+func TestOutputTightensExistingFilePermissions(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("unix file mode regression")
+	}
+	dir := t.TempDir()
+	path := filepath.Join(dir, "out.ndjson")
+	if err := os.WriteFile(path, []byte("old"), 0644); err != nil {
+		t.Fatalf("write existing output: %v", err)
+	}
+
+	cfg := &config.Config{OutputFileName: path, OutputFormat: "json"}
+	w, err := New(cfg, &systeminfo.SystemInfo{}, &Metrics{})
+	if err != nil {
+		t.Fatalf("new writer: %v", err)
+	}
+	if err := w.Close(); err != nil {
+		t.Fatalf("close writer: %v", err)
+	}
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatalf("stat output: %v", err)
+	}
+	if got := info.Mode().Perm(); got != 0600 {
+		t.Fatalf("expected output mode 0600, got %o", got)
+	}
+}
+
 func TestOutputLifecycle(t *testing.T) {
 	tmp, err := os.CreateTemp("", "out*.ndjson")
 	if err != nil {

--- a/src/scanner/delta_cache_test.go
+++ b/src/scanner/delta_cache_test.go
@@ -270,6 +270,17 @@ func TestShouldChunkCacheSensitiveAllCriticalIgnoresLongtail(t *testing.T) {
 	}
 }
 
+func TestShouldChunkCacheSensitiveRejectsCustomCriticalOverride(t *testing.T) {
+	cfg := &config.Config{
+		SensitiveLongtail:  "sampled",
+		SensitiveMatchMode: "all",
+	}
+	patterns := GetPatterns([]string{"email"}, map[string]string{"email": `SENTINEL[0-9]+`}, nil)
+	if shouldChunkCacheSensitive(cfg, patterns) {
+		t.Fatal("expected custom critical override to bypass chunk-sensitive cache reuse")
+	}
+}
+
 func TestDeltaCacheFingerprintIncludesPatternBodies(t *testing.T) {
 	cfg := &config.Config{
 		SearchTerms:       []string{"ALPHA"},

--- a/src/scanner/delta_pipeline.go
+++ b/src/scanner/delta_pipeline.go
@@ -341,7 +341,7 @@ func allSensitivePatternsCritical(patterns map[string]*regexp.Regexp) bool {
 		return false
 	}
 	for name := range patterns {
-		if !sensitive.IsCriticalPattern(name) {
+		if !isBuiltinCriticalPattern(name, patterns) {
 			return false
 		}
 	}

--- a/src/scanner/file_modules.go
+++ b/src/scanner/file_modules.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"regexp"
 	"sort"
+	"strings"
 	"time"
 
 	"safnari/config"
@@ -192,6 +193,13 @@ func sampledSensitiveCoverageApplies(fc *FileContext, patternNames []string) boo
 		return false
 	}
 	if fc.Cfg.SensitiveLongtail != "sampled" {
+		return false
+	}
+	engine := strings.ToLower(strings.TrimSpace(fc.Cfg.SensitiveEngine))
+	if engine == "" {
+		engine = "auto"
+	}
+	if engine == "deterministic" {
 		return false
 	}
 	windowBytes := fc.Cfg.SensitiveWindowBytes

--- a/src/scanner/file_modules.go
+++ b/src/scanner/file_modules.go
@@ -180,6 +180,41 @@ func (fc *FileContext) addWarning(msg string) {
 	fc.warnings = append(fc.warnings, msg)
 }
 
+func (fc *FileContext) noteSampledSensitiveCoverage(patternNames []string) {
+	if !sampledSensitiveCoverageApplies(fc, patternNames) {
+		return
+	}
+	fc.addWarning("sensitive-longtail=sampled inspected selected windows for regex-only sensitive patterns; use sensitive-longtail=full for complete regex coverage")
+}
+
+func sampledSensitiveCoverageApplies(fc *FileContext, patternNames []string) bool {
+	if fc == nil || fc.Cfg == nil || fc.Info == nil || len(fc.SensitivePatterns) == 0 {
+		return false
+	}
+	if fc.Cfg.SensitiveLongtail != "sampled" {
+		return false
+	}
+	windowBytes := fc.Cfg.SensitiveWindowBytes
+	if windowBytes <= 0 {
+		windowBytes = 4096
+	}
+	if fc.Info.Size() <= int64(windowBytes*3) {
+		return false
+	}
+	if len(patternNames) == 0 {
+		patternNames = make([]string, 0, len(fc.SensitivePatterns))
+		for name := range fc.SensitivePatterns {
+			patternNames = append(patternNames, name)
+		}
+	}
+	for _, name := range patternNames {
+		if !isBuiltinCriticalPattern(name, fc.SensitivePatterns) {
+			return true
+		}
+	}
+	return false
+}
+
 func (fc *FileContext) Source() (*ChunkSource, error) {
 	if fc == nil {
 		return nil, fmt.Errorf("file context is nil")
@@ -425,6 +460,7 @@ func (m sensitiveModule) Collect(ctx context.Context, fc *FileContext, data *Fil
 	if !fc.ShouldSearchContent() || len(fc.SensitivePatterns) == 0 {
 		return nil
 	}
+	fc.noteSampledSensitiveCoverage(m.patternNames)
 	results, err := fc.EnsureContentAnalysis()
 	if err != nil {
 		return err
@@ -441,6 +477,9 @@ func (m sensitiveModule) Collect(ctx context.Context, fc *FileContext, data *Fil
 		if sensitiveMatchesMayBeTruncated(counts, effectiveSensitivePerTypeLimit(fc.Cfg), fc.Cfg.SensitiveMaxTotal) || sensitiveMatchMode(fc.Cfg) == "first" {
 			data.SensitiveDataTruncated = true
 		}
+	}
+	if sampledSensitiveCoverageApplies(fc, m.patternNames) {
+		data.SensitiveDataTruncated = true
 	}
 	return nil
 }

--- a/src/scanner/file_processor.go
+++ b/src/scanner/file_processor.go
@@ -368,7 +368,7 @@ func scanForSensitiveDataAdvanced(
 	}
 
 	deterministicMode := engine == "auto" || engine == "deterministic" || engine == "hybrid"
-	criticalPatternNames := filterCriticalPatternNames(patternNames, patterns)
+	criticalPatternNames := filterBuiltinCriticalPatternNames(patternNames, patterns)
 	if deterministicMode && len(criticalPatternNames) > 0 {
 		perTypeLimit := maxPerType
 		if perTypeLimit <= 0 {
@@ -402,7 +402,7 @@ func scanForSensitiveDataAdvanced(
 
 	safeGate := prefilter.BuildSensitiveGateBytes("safe", content, patternNames)
 	for _, dataType := range patternNames {
-		if sensitive.IsCriticalPattern(dataType) {
+		if isBuiltinCriticalPattern(dataType, patterns) {
 			continue
 		}
 		pattern, ok := patterns[dataType]
@@ -422,7 +422,7 @@ func scanForSensitiveDataAdvanced(
 		if perTypeLimit == 0 {
 			continue
 		}
-		if !safeGate.Allow(dataType) {
+		if !sensitive.IsCriticalPattern(dataType) && !safeGate.Allow(dataType) {
 			continue
 		}
 
@@ -444,21 +444,30 @@ func scanForSensitiveDataAdvanced(
 	return matches, matchCounts
 }
 
-func filterCriticalPatternNames(patternNames []string, patterns map[string]*regexp.Regexp) []string {
+func filterBuiltinCriticalPatternNames(patternNames []string, patterns map[string]*regexp.Regexp) []string {
 	if len(patternNames) == 0 || len(patterns) == 0 {
 		return nil
 	}
 	critical := make([]string, 0, len(patternNames))
 	for _, name := range patternNames {
-		if !sensitive.IsCriticalPattern(name) {
-			continue
-		}
-		if _, ok := patterns[name]; !ok {
+		if !isBuiltinCriticalPattern(name, patterns) {
 			continue
 		}
 		critical = append(critical, name)
 	}
 	return critical
+}
+
+func isBuiltinCriticalPattern(name string, patterns map[string]*regexp.Regexp) bool {
+	if !sensitive.IsCriticalPattern(name) {
+		return false
+	}
+	selected, ok := patterns[name]
+	if !ok {
+		return false
+	}
+	builtin, ok := sensitivePatterns[name]
+	return ok && selected == builtin
 }
 
 func regexSensitiveMatches(content []byte, pattern *regexp.Regexp, limit int, longtail string, windowBytes int) []string {

--- a/src/scanner/record.go
+++ b/src/scanner/record.go
@@ -40,6 +40,7 @@ func (r *FileRecord) HasSignalData() bool {
 		len(r.Xattrs) > 0 ||
 		r.ACL != "" ||
 		len(r.AlternateDataStreams) > 0 ||
+		r.SensitiveDataTruncated ||
 		r.ContentScanTruncated ||
 		len(r.CollectionWarnings) > 0
 }

--- a/src/scanner/scan_pipeline.go
+++ b/src/scanner/scan_pipeline.go
@@ -173,7 +173,7 @@ func newStreamSensitiveConsumer(
 	patternNames []string,
 	limit int64,
 ) *streamSensitiveConsumer {
-	critical := filterCriticalPatternNames(patternNames, patterns)
+	critical := filterBuiltinCriticalPatternNames(patternNames, patterns)
 	return &streamSensitiveConsumer{
 		cfg:                  cfg,
 		patterns:             patterns,
@@ -296,7 +296,7 @@ func (c *streamSensitiveConsumer) needsRegexBuffer() bool {
 		return false
 	}
 	for _, name := range c.patternNames {
-		if !sensitive.IsCriticalPattern(name) {
+		if !isBuiltinCriticalPattern(name, c.patterns) {
 			return true
 		}
 	}
@@ -309,7 +309,7 @@ func (c *streamSensitiveConsumer) Finalize() error {
 	}
 	nonCritical := make([]string, 0, len(c.patternNames))
 	for _, name := range c.patternNames {
-		if sensitive.IsCriticalPattern(name) {
+		if isBuiltinCriticalPattern(name, c.patterns) {
 			continue
 		}
 		nonCritical = append(nonCritical, name)

--- a/src/scanner/scanner_test.go
+++ b/src/scanner/scanner_test.go
@@ -753,6 +753,54 @@ func TestSampledLongtailAddsCoverageWarning(t *testing.T) {
 	}
 }
 
+func TestSampledLongtailDeterministicDoesNotWarnForRegexOnlyPattern(t *testing.T) {
+	root := t.TempDir()
+	path := filepath.Join(root, "long.txt")
+	content := []byte(strings.Repeat("a", 20000))
+	if err := os.WriteFile(path, content, 0600); err != nil {
+		t.Fatalf("write long file: %v", err)
+	}
+	outputPath := filepath.Join(root, "out.ndjson")
+	cfg := &config.Config{
+		StartPaths:           []string{root},
+		ScanFiles:            true,
+		ScanSensitive:        true,
+		OutputFileName:       outputPath,
+		OutputFormat:         "json",
+		CollectXattrs:        false,
+		CollectACL:           false,
+		RedactSensitive:      "none",
+		ContentScanMaxBytes:  defaultContentScanMaxBytes,
+		SensitiveEngine:      "deterministic",
+		SensitiveLongtail:    "sampled",
+		SensitiveMatchMode:   "all",
+		SensitiveWindowBytes: 4096,
+	}
+	writer, err := output.New(cfg, &systeminfo.SystemInfo{}, &output.Metrics{})
+	if err != nil {
+		t.Fatalf("new writer: %v", err)
+	}
+	patterns := GetPatterns([]string{"email"}, map[string]string{"email": `SENTINEL[0-9]+`}, nil)
+	if err := ProcessFile(context.Background(), path, cfg, writer, patterns); err != nil {
+		t.Fatalf("process deterministic long file: %v", err)
+	}
+	if err := writer.Close(); err != nil {
+		t.Fatalf("close writer: %v", err)
+	}
+	records := readFileRecords(t, outputPath)
+	if len(records) != 1 {
+		t.Fatalf("expected one baseline file record, got %d", len(records))
+	}
+	if records[0].SensitiveDataTruncated {
+		t.Fatal("did not expect deterministic regex-only scan to mark sampled sensitive data truncated")
+	}
+	for _, warning := range records[0].CollectionWarnings {
+		if strings.Contains(warning, "sensitive-longtail=sampled inspected selected windows") {
+			t.Fatalf("did not expect sampled regex coverage warning in deterministic mode: %q", warning)
+		}
+	}
+}
+
 func TestScanFilesDoesNotWriteLastScanSymlink(t *testing.T) {
 	if runtime.GOOS == "windows" {
 		t.Skip("symlink creation requires elevated privileges on many Windows systems")

--- a/src/scanner/scanner_test.go
+++ b/src/scanner/scanner_test.go
@@ -102,6 +102,15 @@ func TestCustomSensitivePattern(t *testing.T) {
 	}
 }
 
+func TestCustomCriticalPatternUsesCustomRegex(t *testing.T) {
+	content := []byte("marker SENTINEL123")
+	patterns := GetPatterns([]string{"email"}, map[string]string{"email": `SENTINEL[0-9]+`}, nil)
+	matches, _ := scanForSensitiveDataAdvanced(content, patterns, 100, 1000, "auto", "full", 4096, []string{"email"})
+	if got := matches["email"]; len(got) != 1 || got[0] != "SENTINEL123" {
+		t.Fatalf("expected custom critical-name regex match, got %v", got)
+	}
+}
+
 func TestInternationalSensitivePatterns(t *testing.T) {
 	tmp, _ := os.CreateTemp("", "intl*.txt")
 	content := "IBAN GB29NWBK60161331926819 Aadhaar 1234 5678 9012"
@@ -673,6 +682,74 @@ func TestProcessFileSkipsSymlinkInsideScanRoot(t *testing.T) {
 	}
 	if records := readFileRecords(t, outputPath); len(records) != 0 {
 		t.Fatalf("expected symlink to be skipped, got records: %+v", records)
+	}
+}
+
+func TestWalkerRejectsSymlinkScanRoot(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("symlink creation requires elevated privileges on many Windows systems")
+	}
+	outside := t.TempDir()
+	if err := os.WriteFile(filepath.Join(outside, "secret.txt"), []byte("secret"), 0600); err != nil {
+		t.Fatalf("write outside file: %v", err)
+	}
+	root := filepath.Join(t.TempDir(), "rootlink")
+	if err := os.Symlink(outside, root); err != nil {
+		t.Skipf("symlink unavailable: %v", err)
+	}
+	cfg := &config.Config{}
+	discovered := collectWalkedFiles(t, root, cfg)
+	if len(discovered) != 0 {
+		t.Fatalf("expected symlink root to be rejected, got %v", discovered)
+	}
+}
+
+func TestSampledLongtailAddsCoverageWarning(t *testing.T) {
+	root := t.TempDir()
+	path := filepath.Join(root, "long.txt")
+	content := []byte(strings.Repeat("a", 20000))
+	copy(content[6000:], []byte("DE89370400440532013000"))
+	if err := os.WriteFile(path, content, 0600); err != nil {
+		t.Fatalf("write long file: %v", err)
+	}
+	outputPath := filepath.Join(root, "out.ndjson")
+	cfg := &config.Config{
+		StartPaths:           []string{root},
+		ScanFiles:            true,
+		ScanSensitive:        true,
+		OutputFileName:       outputPath,
+		OutputFormat:         "json",
+		CollectXattrs:        false,
+		CollectACL:           false,
+		RedactSensitive:      "none",
+		ContentScanMaxBytes:  defaultContentScanMaxBytes,
+		SensitiveEngine:      "auto",
+		SensitiveLongtail:    "sampled",
+		SensitiveMatchMode:   "all",
+		SensitiveWindowBytes: 4096,
+	}
+	writer, err := output.New(cfg, &systeminfo.SystemInfo{}, &output.Metrics{})
+	if err != nil {
+		t.Fatalf("new writer: %v", err)
+	}
+	if err := ProcessFile(context.Background(), path, cfg, writer, GetPatterns([]string{"iban"}, nil, nil)); err != nil {
+		t.Fatalf("process long file: %v", err)
+	}
+	if err := writer.Close(); err != nil {
+		t.Fatalf("close writer: %v", err)
+	}
+	records := readFileRecords(t, outputPath)
+	if len(records) != 1 {
+		t.Fatalf("expected one warning record, got %d", len(records))
+	}
+	if !records[0].SensitiveDataTruncated {
+		t.Fatal("expected sampled longtail record to be marked truncated")
+	}
+	if len(records[0].CollectionWarnings) == 0 {
+		t.Fatal("expected sampled longtail warning")
+	}
+	if len(records[0].SensitiveData) != 0 {
+		t.Fatalf("expected IBAN outside sampled windows to remain unmatched, got %v", records[0].SensitiveData)
 	}
 }
 

--- a/src/scanner/traversal.go
+++ b/src/scanner/traversal.go
@@ -2,6 +2,7 @@ package scanner
 
 import (
 	"context"
+	"fmt"
 	"io/fs"
 	"os"
 	"path/filepath"
@@ -16,9 +17,12 @@ type walker interface {
 type fastWalker struct{}
 
 func (w fastWalker) Walk(ctx context.Context, startPath string, fn fs.WalkDirFunc) error {
-	info, err := os.Stat(startPath)
+	info, err := os.Lstat(startPath)
 	if err != nil {
 		return fn(startPath, nil, err)
+	}
+	if info.Mode()&os.ModeSymlink != 0 {
+		return fn(startPath, nil, fmt.Errorf("refusing symlink scan root: %s", startPath))
 	}
 	root := fs.FileInfoToDirEntry(info)
 	type item struct {

--- a/src/systeminfo/systeminfo_unix.go
+++ b/src/systeminfo/systeminfo_unix.go
@@ -13,6 +13,7 @@ import (
 	"path/filepath"
 	"runtime"
 	"strings"
+	"syscall"
 	"time"
 )
 
@@ -286,26 +287,113 @@ func appendParsedCronTasks(tasks []string, data []byte) []string {
 func safeCommand(ctx context.Context, name string, args ...string) *exec.Cmd {
 	resolvedName := resolveTrustedCommand(name, trustedCommandPath)
 	cmd := exec.CommandContext(ctx, resolvedName, args...)
-	cmd.Env = withTrustedPath(os.Environ(), trustedCommandPath)
+	cmd.Env = withTrustedPath(os.Environ(), trustedExecutablePath(trustedCommandPath))
 	return cmd
 }
 
 func resolveTrustedCommand(name, trustedPath string) string {
 	if filepath.IsAbs(name) {
-		return name
+		if isTrustedExecutable(name, os.Geteuid()) {
+			return name
+		}
+		return filepath.Join("__safnari_command_not_found__", filepath.Base(name))
 	}
 	for _, dir := range filepath.SplitList(trustedPath) {
 		if dir == "" {
 			continue
 		}
 		candidate := filepath.Join(dir, name)
-		info, err := os.Stat(candidate)
-		if err != nil || info.IsDir() || info.Mode()&0111 == 0 {
+		if !isTrustedExecutable(candidate, os.Geteuid()) {
 			continue
 		}
 		return candidate
 	}
 	return filepath.Join("__safnari_command_not_found__", name)
+}
+
+func trustedExecutablePath(pathList string) string {
+	dirs := filepath.SplitList(pathList)
+	trusted := make([]string, 0, len(dirs))
+	for _, dir := range dirs {
+		if dir == "" || !isTrustedDirectory(dir, os.Geteuid()) {
+			continue
+		}
+		trusted = append(trusted, dir)
+	}
+	return strings.Join(trusted, string(os.PathListSeparator))
+}
+
+func isTrustedExecutable(path string, euid int) bool {
+	info, err := os.Lstat(path)
+	if err != nil || info.IsDir() || info.Mode()&os.ModeSymlink != 0 || info.Mode()&0111 == 0 {
+		return false
+	}
+	if !isTrustedOwnerAndMode(info, euid) {
+		return false
+	}
+	return isTrustedPathChain(filepath.Dir(path), euid)
+}
+
+func isTrustedDirectory(path string, euid int) bool {
+	info, err := os.Lstat(path)
+	if err != nil || !info.IsDir() || info.Mode()&os.ModeSymlink != 0 {
+		return false
+	}
+	if !isTrustedOwnerAndMode(info, euid) {
+		return false
+	}
+	return isTrustedPathChain(path, euid)
+}
+
+func isTrustedPathChain(path string, euid int) bool {
+	abs, err := filepath.Abs(path)
+	if err != nil {
+		return false
+	}
+	abs = filepath.Clean(abs)
+	volume := filepath.VolumeName(abs)
+	rest := strings.TrimPrefix(abs, volume)
+	rest = strings.Trim(rest, string(filepath.Separator))
+	current := volume + string(filepath.Separator)
+	if volume == "" {
+		current = string(filepath.Separator)
+	}
+	if rest == "" {
+		info, err := os.Lstat(current)
+		if err != nil || !info.IsDir() || info.Mode()&os.ModeSymlink != 0 {
+			return false
+		}
+		return isTrustedOwnerAndMode(info, euid)
+	}
+	for _, part := range strings.Split(rest, string(filepath.Separator)) {
+		if part == "" {
+			continue
+		}
+		current = filepath.Join(current, part)
+		info, err := os.Lstat(current)
+		if err != nil || !info.IsDir() || info.Mode()&os.ModeSymlink != 0 {
+			return false
+		}
+		if !isTrustedOwnerAndMode(info, euid) {
+			return false
+		}
+	}
+	return true
+}
+
+func isTrustedOwnerAndMode(info os.FileInfo, euid int) bool {
+	if info.Mode()&0022 != 0 {
+		return false
+	}
+	stat, ok := info.Sys().(*syscall.Stat_t)
+	if !ok {
+		return false
+	}
+	uid := int(stat.Uid)
+	if euid == 0 {
+		return uid == 0
+	}
+	return uid == 0 || uid == euid
 }
 
 func withTrustedPath(env []string, trustedPath string) []string {

--- a/src/systeminfo/systeminfo_unix.go
+++ b/src/systeminfo/systeminfo_unix.go
@@ -334,21 +334,14 @@ func trustedExecutablePath(pathList string) string {
 }
 
 func isTrustedExecutable(path string, euid int) bool {
-	info, err := os.Lstat(path)
-	if err != nil || info.IsDir() {
+	resolvedPath, err := filepath.EvalSymlinks(path)
+	if err != nil {
 		return false
 	}
-	if info.Mode()&os.ModeSymlink != 0 {
-		if !isTrustedPathChain(filepath.Dir(path), euid) {
-			return false
-		}
-		resolvedPath, err := filepath.EvalSymlinks(path)
-		if err != nil {
-			return false
-		}
-		return isTrustedExecutableFile(resolvedPath, euid)
+	if !isTrustedDirectoryPath(filepath.Dir(path), euid) {
+		return false
 	}
-	return isTrustedExecutableFile(path, euid)
+	return isTrustedExecutableFile(resolvedPath, euid)
 }
 
 func isTrustedExecutableFile(path string, euid int) bool {
@@ -363,8 +356,25 @@ func isTrustedExecutableFile(path string, euid int) bool {
 }
 
 func isTrustedDirectory(path string, euid int) bool {
+	return isTrustedDirectoryPath(path, euid)
+}
+
+func isTrustedDirectoryPath(path string, euid int) bool {
 	info, err := os.Lstat(path)
-	if err != nil || !info.IsDir() || info.Mode()&os.ModeSymlink != 0 {
+	if err != nil {
+		return false
+	}
+	if info.Mode()&os.ModeSymlink != 0 {
+		if !isTrustedPathChain(filepath.Dir(path), euid) {
+			return false
+		}
+		resolvedPath, err := filepath.EvalSymlinks(path)
+		if err != nil {
+			return false
+		}
+		return isTrustedPathChain(resolvedPath, euid)
+	}
+	if !info.IsDir() {
 		return false
 	}
 	if !isTrustedOwnerAndMode(info, euid) {

--- a/src/systeminfo/systeminfo_unix.go
+++ b/src/systeminfo/systeminfo_unix.go
@@ -42,6 +42,8 @@ var (
 	}
 )
 
+const unresolvedCommandDir = "/__safnari_command_not_found__"
+
 const trustedCommandPath = "/usr/sbin:/usr/bin:/sbin:/bin:/usr/local/bin:/opt/homebrew/bin"
 
 func gatherOSVersion(sysInfo *SystemInfo) error {
@@ -296,7 +298,7 @@ func resolveTrustedCommand(name, trustedPath string) string {
 		if isTrustedExecutable(name, os.Geteuid()) {
 			return name
 		}
-		return filepath.Join("__safnari_command_not_found__", filepath.Base(name))
+		return unresolvedCommandPath(name)
 	}
 	for _, dir := range filepath.SplitList(trustedPath) {
 		if dir == "" {
@@ -308,7 +310,15 @@ func resolveTrustedCommand(name, trustedPath string) string {
 		}
 		return candidate
 	}
-	return filepath.Join("__safnari_command_not_found__", name)
+	return unresolvedCommandPath(name)
+}
+
+func unresolvedCommandPath(name string) string {
+	base := filepath.Base(name)
+	if base == "." || base == string(filepath.Separator) || base == "" {
+		base = "command"
+	}
+	return filepath.Join(unresolvedCommandDir, base)
 }
 
 func trustedExecutablePath(pathList string) string {
@@ -325,7 +335,25 @@ func trustedExecutablePath(pathList string) string {
 
 func isTrustedExecutable(path string, euid int) bool {
 	info, err := os.Lstat(path)
-	if err != nil || info.IsDir() || info.Mode()&os.ModeSymlink != 0 || info.Mode()&0111 == 0 {
+	if err != nil || info.IsDir() {
+		return false
+	}
+	if info.Mode()&os.ModeSymlink != 0 {
+		if !isTrustedPathChain(filepath.Dir(path), euid) {
+			return false
+		}
+		resolvedPath, err := filepath.EvalSymlinks(path)
+		if err != nil {
+			return false
+		}
+		return isTrustedExecutableFile(resolvedPath, euid)
+	}
+	return isTrustedExecutableFile(path, euid)
+}
+
+func isTrustedExecutableFile(path string, euid int) bool {
+	info, err := os.Lstat(path)
+	if err != nil || !info.Mode().IsRegular() || info.Mode()&0111 == 0 {
 		return false
 	}
 	if !isTrustedOwnerAndMode(info, euid) {

--- a/src/systeminfo/systeminfo_unix_parsing_test.go
+++ b/src/systeminfo/systeminfo_unix_parsing_test.go
@@ -10,6 +10,7 @@ import (
 	"path/filepath"
 	"reflect"
 	"runtime"
+	"strings"
 	"testing"
 )
 
@@ -88,6 +89,29 @@ func TestSafeCommandResolvesAgainstTrustedPath(t *testing.T) {
 	}
 	if cmd.Path == "sh" {
 		t.Fatalf("safeCommand left bare executable unresolved")
+	}
+}
+
+func TestResolveTrustedCommandSkipsRootUnsafeDirectory(t *testing.T) {
+	tmpDir := t.TempDir()
+	unsafeDir := filepath.Join(tmpDir, "unsafe")
+	if err := os.Mkdir(unsafeDir, 0777); err != nil {
+		t.Fatalf("mkdir unsafe: %v", err)
+	}
+	if err := os.Chmod(unsafeDir, 0777); err != nil {
+		t.Fatalf("chmod unsafe: %v", err)
+	}
+	unsafeCmd := filepath.Join(unsafeDir, "sh")
+	if err := os.WriteFile(unsafeCmd, []byte("#!/bin/sh\nexit 1\n"), 0755); err != nil {
+		t.Fatalf("write unsafe cmd: %v", err)
+	}
+
+	got := resolveTrustedCommand("sh", unsafeDir+string(os.PathListSeparator)+"/bin")
+	if got == unsafeCmd || got == "sh" || strings.Contains(got, "__safnari_command_not_found__") {
+		t.Fatalf("expected resolver to skip unsafe command and find trusted shell, got %s", got)
+	}
+	if isTrustedExecutable(unsafeCmd, 0) {
+		t.Fatal("expected root trust check to reject command under writable directory")
 	}
 }
 

--- a/src/systeminfo/systeminfo_unix_parsing_test.go
+++ b/src/systeminfo/systeminfo_unix_parsing_test.go
@@ -11,6 +11,7 @@ import (
 	"reflect"
 	"runtime"
 	"strings"
+	"syscall"
 	"testing"
 )
 
@@ -113,6 +114,66 @@ func TestResolveTrustedCommandSkipsRootUnsafeDirectory(t *testing.T) {
 	if isTrustedExecutable(unsafeCmd, 0) {
 		t.Fatal("expected root trust check to reject command under writable directory")
 	}
+}
+
+func TestResolveTrustedCommandUsesAbsoluteMissingSentinel(t *testing.T) {
+	got := resolveTrustedCommand("missing-command", "")
+	if !filepath.IsAbs(got) {
+		t.Fatalf("expected missing command sentinel to be absolute, got %s", got)
+	}
+	if filepath.Dir(got) != unresolvedCommandDir {
+		t.Fatalf("expected missing command under sentinel dir, got %s", got)
+	}
+}
+
+func TestIsTrustedExecutableAllowsTrustedSymlinkTarget(t *testing.T) {
+	tmpDir := trustedTempDir(t)
+	target := filepath.Join(tmpDir, "target-sh")
+	if err := os.WriteFile(target, []byte("#!/bin/sh\nexit 0\n"), 0700); err != nil {
+		t.Fatalf("write target: %v", err)
+	}
+	link := filepath.Join(tmpDir, "sh")
+	if err := os.Symlink(target, link); err != nil {
+		t.Fatalf("symlink target: %v", err)
+	}
+
+	if !isTrustedExecutable(link, os.Geteuid()) {
+		t.Fatalf("expected trusted symlink executable to be accepted: %s", link)
+	}
+}
+
+func TestIsTrustedExecutableRejectsNonRegularFile(t *testing.T) {
+	tmpDir := trustedTempDir(t)
+	fifo := filepath.Join(tmpDir, "fifo")
+	if err := syscall.Mkfifo(fifo, 0700); err != nil {
+		t.Fatalf("mkfifo: %v", err)
+	}
+
+	if isTrustedExecutable(fifo, os.Geteuid()) {
+		t.Fatalf("expected non-regular file to be rejected: %s", fifo)
+	}
+}
+
+func trustedTempDir(t *testing.T) string {
+	t.Helper()
+
+	wd, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("get cwd: %v", err)
+	}
+	tmpDir, err := os.MkdirTemp(wd, "trusted-command-")
+	if err != nil {
+		t.Fatalf("mkdir temp in cwd: %v", err)
+	}
+	t.Cleanup(func() {
+		if err := os.RemoveAll(tmpDir); err != nil {
+			t.Fatalf("cleanup temp dir: %v", err)
+		}
+	})
+	if err := os.Chmod(tmpDir, 0700); err != nil {
+		t.Fatalf("chmod temp dir: %v", err)
+	}
+	return tmpDir
 }
 
 func TestGatherUsersGroupsAdminsWithInjectedFiles(t *testing.T) {

--- a/src/systeminfo/systeminfo_unix_parsing_test.go
+++ b/src/systeminfo/systeminfo_unix_parsing_test.go
@@ -142,6 +142,27 @@ func TestIsTrustedExecutableAllowsTrustedSymlinkTarget(t *testing.T) {
 	}
 }
 
+func TestResolveTrustedCommandAllowsTrustedSymlinkDirectory(t *testing.T) {
+	tmpDir := trustedTempDir(t)
+	realBin := filepath.Join(tmpDir, "real-bin")
+	if err := os.Mkdir(realBin, 0700); err != nil {
+		t.Fatalf("mkdir real bin: %v", err)
+	}
+	target := filepath.Join(realBin, "sh")
+	if err := os.WriteFile(target, []byte("#!/bin/sh\nexit 0\n"), 0700); err != nil {
+		t.Fatalf("write target: %v", err)
+	}
+	linkBin := filepath.Join(tmpDir, "bin")
+	if err := os.Symlink(realBin, linkBin); err != nil {
+		t.Fatalf("symlink bin: %v", err)
+	}
+
+	got := resolveTrustedCommand("sh", linkBin)
+	if got == "sh" || strings.Contains(got, unresolvedCommandDir) {
+		t.Fatalf("expected trusted symlink directory command to resolve, got %s", got)
+	}
+}
+
 func TestIsTrustedExecutableRejectsNonRegularFile(t *testing.T) {
 	tmpDir := trustedTempDir(t)
 	fifo := filepath.Join(tmpDir, "fifo")

--- a/src/utils/path.go
+++ b/src/utils/path.go
@@ -32,7 +32,7 @@ func getPathGuard(roots []string) *pathGuard {
 		if err != nil {
 			continue
 		}
-		normalizedRoots = append(normalizedRoots, filepath.Clean(absRoot))
+		normalizedRoots = append(normalizedRoots, canonicalPath(absRoot))
 	}
 	guard := &pathGuard{roots: normalizedRoots}
 	actual, _ := pathGuardCache.LoadOrStore(key, guard)
@@ -47,7 +47,7 @@ func (g *pathGuard) Contains(path string) bool {
 	if err != nil {
 		return false
 	}
-	absPath = filepath.Clean(absPath)
+	absPath = canonicalPath(absPath)
 
 	for _, absRoot := range g.roots {
 		rel, err := filepath.Rel(absRoot, absPath)
@@ -59,4 +59,38 @@ func (g *pathGuard) Contains(path string) bool {
 		}
 	}
 	return false
+}
+
+func canonicalPath(path string) string {
+	cleaned := filepath.Clean(path)
+	resolved, err := filepath.EvalSymlinks(cleaned)
+	if err != nil {
+		return canonicalExistingPrefix(cleaned)
+	}
+	return filepath.Clean(resolved)
+}
+
+func canonicalExistingPrefix(path string) string {
+	volume := filepath.VolumeName(path)
+	rest := strings.TrimPrefix(path, volume)
+	rest = strings.Trim(rest, string(filepath.Separator))
+	if rest == "" {
+		return path
+	}
+	parts := strings.Split(rest, string(filepath.Separator))
+	for i := len(parts); i > 0; i-- {
+		prefix := volume + string(filepath.Separator) + filepath.Join(parts[:i]...)
+		if volume == "" {
+			prefix = string(filepath.Separator) + filepath.Join(parts[:i]...)
+		}
+		resolved, err := filepath.EvalSymlinks(prefix)
+		if err != nil {
+			continue
+		}
+		if i == len(parts) {
+			return filepath.Clean(resolved)
+		}
+		return filepath.Clean(filepath.Join(append([]string{resolved}, parts[i:]...)...))
+	}
+	return path
 }

--- a/src/utils/path_test.go
+++ b/src/utils/path_test.go
@@ -1,7 +1,9 @@
 package utils
 
 import (
+	"os"
 	"path/filepath"
+	"runtime"
 	"testing"
 )
 
@@ -26,5 +28,23 @@ func TestPathGuardContainsMultipleRoots(t *testing.T) {
 	guard := getPathGuard([]string{rootA, rootB})
 	if !guard.Contains(inB) {
 		t.Fatalf("expected guard to include path under second root")
+	}
+}
+
+func TestIsPathWithinRejectsSymlinkParentEscape(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("symlink creation requires elevated privileges on many Windows systems")
+	}
+	root := t.TempDir()
+	outside := t.TempDir()
+	if err := os.WriteFile(filepath.Join(outside, "secret.txt"), []byte("secret"), 0600); err != nil {
+		t.Fatalf("write outside file: %v", err)
+	}
+	link := filepath.Join(root, "linked")
+	if err := os.Symlink(outside, link); err != nil {
+		t.Skipf("symlink unavailable: %v", err)
+	}
+	if IsPathWithin(filepath.Join(link, "secret.txt"), []string{root}) {
+		t.Fatal("expected symlinked parent escape to be outside canonical root")
 	}
 }


### PR DESCRIPTION
## Summary
- harden output file creation so reused Unix output files are tightened to owner-only permissions
- canonicalize scanner path containment, reject symlink scan roots, and preserve custom critical regex behavior
- trust-filter system information command resolution and PATH candidates before execution
- surface sampled long-tail sensitive coverage warnings and emit warning-only records
- add regression coverage for the remediated security findings

## Validation
- `make lint`
- `make test`

## Security scan context
These changes remediate the Codex Security findings around output confidentiality, scanner traversal boundaries, trusted command execution, custom critical pattern matching, and sampled sensitive-data coverage visibility.
